### PR TITLE
Added support for command aliases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ module.exports = class MyCommand extends Command {
   constructor(client) {
     super(client, {
       name: 'cmd', // The command's name. In this case, users need to write !cmd for the command to work.,
+      aliases: ['mycmd', 'alias2'], // The command's aliases. With this, users can write !mycmd and !alias2 for the command to work.
       description: 'My command.', // The command's description.
       group: 'my_group', // The ID of the group that holds this command.
       emoji: ':robot:', // The emoji that represents this command. This is used by the default HelpCommand. Defaults to ':robot:'.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@greencoast/discord.js-extended",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@greencoast/discord.js-extended",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "An utility to facilitate the repetitive tasks when creating discord bots. Used by Greencoast Studios.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/classes/command/Command.ts
+++ b/src/classes/command/Command.ts
@@ -94,6 +94,14 @@ abstract class Command {
   public nsfw: boolean;
 
   /**
+   * Aliases for this command.
+   * @type {string[]}
+   * @memberof Command
+   * @defaultValue `[]`
+   */
+  public aliases: string[];
+
+  /**
    * @param client The client that this command will be used by.
    * @param info This command's specific information.
    */
@@ -110,6 +118,7 @@ abstract class Command {
     this.userPermissions = info.userPermissions || null;
     this.ownerOverride = info.ownerOverride || true;
     this.nsfw = info.nsfw || false;
+    this.aliases = info.aliases || [];
   }
 
   /**

--- a/src/classes/command/CommandDispatcher.ts
+++ b/src/classes/command/CommandDispatcher.ts
@@ -46,7 +46,7 @@ class CommandDispatcher {
     const args = message.content.slice(this.client.prefix.length).trim().split(/ +/);
     const commandName = args.shift()?.toLowerCase();
 
-    const command = this.registry.commands.get(commandName!);
+    const command = this.registry.resolveCommand(commandName!);
 
     if (!command || command.guildOnly && !message.guild) {
       return;

--- a/src/classes/command/CommandRegistry.ts
+++ b/src/classes/command/CommandRegistry.ts
@@ -42,6 +42,15 @@ class CommandRegistry {
   }
 
   /**
+   * Resolves the command from this registry corresponding to its name or alias.
+   * @param name The name or alias of the command.
+   * @returns The resolved command, or `undefined` if no command is resolved.
+   */
+  public resolveCommand(name: string): Command | undefined {
+    return this.commands.get(name) || this.commands.find((command) => command.aliases.includes(name));
+  }
+
+  /**
    * Register a command group.
    * @param id The ID of the group.
    * @param name The name of the group.

--- a/src/interfaces/CommandInfo.ts
+++ b/src/interfaces/CommandInfo.ts
@@ -54,7 +54,13 @@ interface CommandInfo {
    * Whether this command may only be used in a NSFW channel.
    * @defaultValue `false`
    */
-  nsfw?: boolean
+  nsfw?: boolean,
+
+  /**
+   * Aliases for this command.
+   * @defaultValue `[]`
+   */
+  aliases?: string[]
 }
 
 export default CommandInfo;

--- a/test/classes/command/CommandRegistry.spec.ts
+++ b/test/classes/command/CommandRegistry.spec.ts
@@ -181,5 +181,35 @@ describe('Classes: Command: CommandRegistry', () => {
         expect(registry.registerDefaultCommands).toHaveBeenCalledTimes(1);
       });
     });
+
+    describe('resolveCommand()', () => {
+      beforeEach(() => {
+        registry.registerGroups([
+          ['group1', 'Group1'],
+          ['group2', 'Group2']
+        ]);
+        registry.registerCommands([
+          new ConcreteCommand(clientMock, { name: 'cmdName', group: 'group1' }),
+          new ConcreteCommand(clientMock, { name: 'cmdNameWithAlias', group: 'group2', aliases: ['alias1', 'alias2'] })
+        ]);
+      });
+
+      it('should return undefined if no command is found.', () => {
+        expect(registry.resolveCommand('unknown')).toBeUndefined();
+      });
+
+      it('should return a command if the command is found by name.', () => {
+        expect(registry.resolveCommand('cmdName')).toHaveProperty('name', 'cmdName');
+      });
+
+      it('should return a command if the command with alias is found by name.', () => {
+        expect(registry.resolveCommand('cmdNameWithAlias')).toHaveProperty('name', 'cmdNameWithAlias');
+      });
+
+      it('should return a command if the command with alias is found by alias.', () => {
+        expect(registry.resolveCommand('alias1')).toHaveProperty('name', 'cmdNameWithAlias');
+        expect(registry.resolveCommand('alias2')).toHaveProperty('name', 'cmdNameWithAlias');
+      });
+    });
   });
 });


### PR DESCRIPTION
### :pencil: Checklist

Make sure that your PR fulfills these requirements:

- [x] Tests have been added for this feature.
- [x] Code is properly documented.
- [x] All tests pass on your local machine.
- [x] Code has been linted with the proper rules.

### :page_facing_up: Description

This PR adds support adding aliases to commands.

### :pushpin: Does this PR address any issue?

#14
