### PR TITLE
Added checks to registerCommand to avoid unexpected behavior in command registry based on repeated aliases.

### DIFF
--- a/src/classes/command/CommandRegistry.ts
+++ b/src/classes/command/CommandRegistry.ts
@@ -93,6 +93,8 @@ class CommandRegistry {
    * @returns This command registry.
    * @throws Throws if the command's `groupID` is not registered.
    * @throws Throws if the command's `name` is already registered.
+   * @throws Throws if the command's `name` is also specified as its own `alias`.
+   * @throws Throws if any of the command's `aliases` is already registered.
    * @emits `client#commandRegistered`
    */
   public registerCommand(command: Command): this {
@@ -129,6 +131,8 @@ class CommandRegistry {
    * @returns This command registry.
    * @throws Throws if any of the command's `groupID` is not registered.
    * @throws Throws if any of the command's `name` is already registered.
+   * @throws Throws if any of the command's `name` is also specified as its own `alias`.
+   * @throws Throws if any of the command's `aliases` is already registered.
    * @emits `client#commandRegistered`
    */
   public registerCommands(commands: Command[]): this {
@@ -146,6 +150,8 @@ class CommandRegistry {
    * @throws Throws if any of the command's `groupID` is not registered.
    * This may happen if a command with an unregistered group is located inside a registered group subdirectory.
    * @throws Throws if any of the command's `name` is already registered.
+   * @throws Throws if any the command's `name` is also specified as its own `alias`.
+   * @throws Throws if any of the command's `aliases` is already registered.
    * @emits `client#commandRegistered`
    * @returns This command registry.
    */

--- a/src/classes/command/CommandRegistry.ts
+++ b/src/classes/command/CommandRegistry.ts
@@ -102,8 +102,18 @@ class CommandRegistry {
       throw new Error(`Group ${command.groupID} is not registered.`);
     }
 
-    if (this.commands.has(command.name)) {
+    if (this.resolveCommand(command.name)) {
       throw new Error(`Command ${command.name} is already registered.`);
+    }
+
+    for (const alias of command.aliases) {
+      if (this.resolveCommand(alias)) {
+        throw new Error(`Command ${alias} is already registered.`);
+      }
+
+      if (alias === command.name) {
+        throw new Error(`Command ${command.name} contains its own name as an alias. Please remove ${command.name} from its aliases.`);
+      }
     }
 
     group.registerCommand(command);

--- a/test/classes/command/CommandRegistry.spec.ts
+++ b/test/classes/command/CommandRegistry.spec.ts
@@ -77,7 +77,30 @@ describe('Classes: Command: CommandRegistry', () => {
       }).toThrow();
     });
 
-    it('should throw if command is already registered.', () => {
+    it('should throw if command is already registered by name.', () => {
+      expect(() => {
+        registry.registerCommand(command);
+      }).toThrow();
+    });
+
+    it('should throw if command is already registered by alias.', () => {
+      const command1 = new ConcreteCommand(clientMock, { name: 'cmd', aliases: ['commando'] });
+      const command2 = new ConcreteCommand(clientMock, { name: 'cmd2', aliases: ['cm3', 'cmd'] });
+      const command3 = new ConcreteCommand(clientMock, { name: 'cmd3', aliases: ['commando'] });
+
+      registry.registerCommand(command1);
+
+      expect(() => {
+        registry.registerCommand(command2);
+      }).toThrow();
+      expect(() => {
+        registry.registerCommand(command3);
+      }).toThrow();
+    });
+
+    it('should throw if command aliases contain command name.', () => {
+      const command = new ConcreteCommand(clientMock, { name: 'cmd', aliases: ['cm3', 'cmd'] });
+
       expect(() => {
         registry.registerCommand(command);
       }).toThrow();


### PR DESCRIPTION
### :pencil: Checklist

Make sure that your PR fulfills these requirements:

- [x] Tests have been added for this feature.
- [x] Code is properly documented.
- [x] All tests pass on your local machine.
- [x] Code has been linted with the proper rules.
- [x] I have added the correct assignees for code review.

### :page_facing_up: Description

This PR adds some checks to avoid unexpected behavior when registering command that share aliases.

### :pushpin: Does this PR address any issue?

#25
