### PR TITLE
Version 1.2.1

### DIFF
--- a/__mocks__/discord.js.ts
+++ b/__mocks__/discord.js.ts
@@ -42,7 +42,8 @@ class ClientMock {
       cache: {
         reduce: (fn: any, initial: any) => {
           return [{ memberCount: 10 }, { memberCount: 5 }, { memberCount: 2 }].reduce(fn, initial);
-        }
+        },
+        size: 3
       }
     };
     this.users = {
@@ -128,6 +129,14 @@ class MessageEmbedMock {
   }
 }
 
+class ShardClientUtilMock {
+  public fetchClientValues: jest.Mock<any, any>;
+
+  constructor() {
+    this.fetchClientValues = jest.fn();
+  }
+}
+
 export {
   rateLimitMock
 };
@@ -139,5 +148,6 @@ export default {
   User: UserMock,
   Message: MessageMock,
   MessageEmbed: MessageEmbedMock,
+  ShardClientUtil: ShardClientUtilMock,
   Collection: RealDiscord.Collection
 };

--- a/example/index.js
+++ b/example/index.js
@@ -24,7 +24,7 @@ const client = new ExtendedClient({
   prefix: config.get('PREFIX'),
   owner: '191330192868769793',
   debug: true,
-  presence: {
+  presence: {
     templates: ['{num_guilds} guilds!', '{num_members} members!', 'owner: {owner_name}', '{uptime}', '{ready_time}'],
     refreshInterval: 10000, // Presence gets changed every 10 seconds.
     status: 'dnd',

--- a/example/package.json
+++ b/example/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node .",
+    "start-shard": "node sharded-client.js",
     "dev": "nodemon ."
   },
   "dependencies": {

--- a/example/sharded-client.js
+++ b/example/sharded-client.js
@@ -1,0 +1,22 @@
+require('dotenv').config();
+const path = require('path');
+const logger = require('@greencoast/logger');
+const { ShardingManager } = require('discord.js');
+const { ConfigProvider } = require('@greencoast/discord.js-extended');
+
+// The environment object contains the property: DISCORD_TOKEN with the bot's token.
+const config = new ConfigProvider({
+  env: process.env,
+  configPath: path.join(__dirname, './config/settings.json'),
+  types: {
+    TOKEN: 'string'
+  }
+});
+
+const manager = new ShardingManager('./index.js', { token: config.get('TOKEN') });
+
+manager.on('shardCreate', (shard) => {
+  logger.log(`Launched shard with ID: ${shard.id}`);
+});
+
+manager.spawn(2);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@greencoast/discord.js-extended",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@greencoast/discord.js-extended",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "An utility to facilitate the repetitive tasks when creating discord bots. Used by Greencoast Studios.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/classes/abstract/AsyncTemplater.ts
+++ b/src/classes/abstract/AsyncTemplater.ts
@@ -1,0 +1,48 @@
+/**
+ * An abstract class that helps with the application of templates in strings that require
+ * values computed asynchronously.
+ * Wrap the template in curly braces inside the string you want to apply the template to.
+ */
+abstract class AsyncTemplater {
+  /**
+   * The keys handled by this async templater. They don't include the curly braces.
+   * @type {string[]}
+   * @memberof AsyncTemplater
+   */
+  public keys: string[];
+
+  /**
+   * @param keys All the keys that should be replaced inside the string.
+   */
+  constructor(keys: string[]) {
+    this.keys = keys;
+  }
+
+  /**
+   * Get the actual value that will replace the key inside the template.
+   * @param key The key to replace.
+   * @returns A promise that resolves to the corresponding string for the given key.
+   * @throws Throws if given key does not correspond to this async templater.
+   */
+  public abstract get(key: string): Promise<string>;
+
+  /**
+   * Apply the template.
+   * @param str The string to process.
+   * @returns A promise that resolves to the string with the templates replaced.
+   */
+  public async apply(str: string): Promise<string> {
+    return this.keys.reduce(async(curPromise, key) => {
+      const cur = await curPromise;
+      const regex = new RegExp(`{${key}}`, 'gi');
+
+      if (regex.test(cur)) {
+        return cur.replace(regex, await this.get(key));
+      }
+
+      return cur;
+    }, Promise.resolve(str));
+  }
+}
+
+export default AsyncTemplater;

--- a/src/classes/abstract/Templater.ts
+++ b/src/classes/abstract/Templater.ts
@@ -20,6 +20,8 @@ abstract class Templater {
   /**
    * Get the actual value that will replace the key inside the template.
    * @param key The key to replace.
+   * @returns The corresponding string for the given key.
+   * @throws Throws if given key does not correspond to this templater.
    */
   public abstract get(key: string): string;
 
@@ -30,7 +32,13 @@ abstract class Templater {
    */
   public apply(str: string): string {
     return this.keys.reduce((cur, key) => {
-      return cur.replace(new RegExp(`{${key}}`, 'gi'), this.get(key));
+      const regex = new RegExp(`{${key}}`, 'gi');
+
+      if (regex.test(cur)) {
+        return cur.replace(regex, this.get(key));
+      }
+
+      return cur;
     }, str);
   }
 }

--- a/src/classes/command/CommandRegistry.ts
+++ b/src/classes/command/CommandRegistry.ts
@@ -93,6 +93,8 @@ class CommandRegistry {
    * @returns This command registry.
    * @throws Throws if the command's `groupID` is not registered.
    * @throws Throws if the command's `name` is already registered.
+   * @throws Throws if the command's `name` is also specified as its own `alias`.
+   * @throws Throws if any of the command's `aliases` is already registered.
    * @emits `client#commandRegistered`
    */
   public registerCommand(command: Command): this {
@@ -102,8 +104,18 @@ class CommandRegistry {
       throw new Error(`Group ${command.groupID} is not registered.`);
     }
 
-    if (this.commands.has(command.name)) {
+    if (this.resolveCommand(command.name)) {
       throw new Error(`Command ${command.name} is already registered.`);
+    }
+
+    for (const alias of command.aliases) {
+      if (this.resolveCommand(alias)) {
+        throw new Error(`Command ${alias} is already registered.`);
+      }
+
+      if (alias === command.name) {
+        throw new Error(`Command ${command.name} contains its own name as an alias. Please remove ${command.name} from its aliases.`);
+      }
     }
 
     group.registerCommand(command);
@@ -119,6 +131,8 @@ class CommandRegistry {
    * @returns This command registry.
    * @throws Throws if any of the command's `groupID` is not registered.
    * @throws Throws if any of the command's `name` is already registered.
+   * @throws Throws if any of the command's `name` is also specified as its own `alias`.
+   * @throws Throws if any of the command's `aliases` is already registered.
    * @emits `client#commandRegistered`
    */
   public registerCommands(commands: Command[]): this {
@@ -136,6 +150,8 @@ class CommandRegistry {
    * @throws Throws if any of the command's `groupID` is not registered.
    * This may happen if a command with an unregistered group is located inside a registered group subdirectory.
    * @throws Throws if any of the command's `name` is already registered.
+   * @throws Throws if any the command's `name` is also specified as its own `alias`.
+   * @throws Throws if any of the command's `aliases` is already registered.
    * @emits `client#commandRegistered`
    * @returns This command registry.
    */

--- a/src/classes/presence/PresenceManager.ts
+++ b/src/classes/presence/PresenceManager.ts
@@ -87,8 +87,8 @@ class PresenceManager {
    * @emits `client#presenceUpdated`
    * @emits `client#presenceUpdateError`
    */
-  public update(status: string, data: PresenceData = {}): Promise<void> | undefined {
-    const processedStatus = this.templater.apply(status);
+  public async update(status: string, data: PresenceData = {}): Promise<void> {
+    const processedStatus = await this.templater.apply(status);
     const presenceData = { ...this.options, ...data };
 
     return this.client.user?.setPresence({
@@ -117,7 +117,7 @@ class PresenceManager {
   public setRefreshInterval(refreshInterval: number | null = null): void {
     if (!refreshInterval) {
       this.options.refreshInterval = null;
-      
+
       if (this.refreshIntervalHandle) {
         clearInterval(this.refreshIntervalHandle);
       }
@@ -140,7 +140,7 @@ class PresenceManager {
 
     this.randomlyUpdate();
     this.refreshIntervalHandle = setInterval(() => this.randomlyUpdate(), refreshInterval);
-    
+
     this.client.emit('presenceRefreshInterval', this.options.refreshInterval);
   }
 
@@ -150,7 +150,7 @@ class PresenceManager {
    * @emits `client#presenceUpdated`
    * @emits `client#presenceUpdateError`
    */
-  public randomlyUpdate(): Promise<void> | undefined {
+  public randomlyUpdate(): Promise<void> {
     return this.update(randomArrayItem(this.options.templates!));
   }
 }

--- a/src/classes/presence/PresenceTemplater.ts
+++ b/src/classes/presence/PresenceTemplater.ts
@@ -1,15 +1,16 @@
+import Discord from 'discord.js';
 import humanizeDuration from 'humanize-duration';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 import ExtendedClient from '../ExtendedClient';
-import Templater from '../abstract/Templater';
+import AsyncTemplater from '../abstract/AsyncTemplater';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
 /**
- * A templater class to help with the application of templates for presence statuses.
+ * An async templater class to help with the application of templates for presence statuses.
  *
  * Supported templates:
  *
@@ -19,23 +20,22 @@ dayjs.extend(timezone);
  * | `{prefix}`       | Get the prefix used by the client.                                                                                          |
  * | `{cur_time}`     | Get the current time in the client's locale.                                                                                |
  * | `{owner_name}`   | Get the owner's name. If no owner is specified then it returns `undefined`.                                                 |
- * | `{client_name}`  | Get the client's name. If the client's user is not ready yet then it returns `undefined`.                                   |
+ * | `{client_name}`  | Get the client's name. If the client's user is not ready yet, then it returns `undefined`.                                   |
  * | `{uptime}`       | Get the client's uptime since last ready event emitted in a human-readable shape. Returns `null` if no uptime is available. |
- * | `{ready_time}`   | Get the client's time at which the last ready event was emitted. Returns `null` if no `readyAt` timestamp is available.     |
+ * | `{ready_time}`   | Get the client's time at which the last ready event was emitted. Returns `null` if no `readyAt` timestamp is available.     |
  * | `{num_members}`  | Get the total number of members across all the guilds that the client is connected to.                                      |
  * | `{num_commands}` | Get the number of commands registered to this client.                                                                       |
  */
-class PresenceTemplater extends Templater {
+class PresenceTemplater extends AsyncTemplater {
   /**
-   * The client that this presence templater will use as a data source.
+   * The client that this presence async templater will use as a data source.
    * @type {ExtendedClient}
    * @memberof PresenceTemplater
    */
   public readonly client: ExtendedClient;
 
   /**
-   * @param client The client that this presence templater will use as a data source.
-   * @throws Throws if given key does not correspond to this templater.
+   * @param client The client that this presence async templater will use as a data source.
    */
   constructor(client: ExtendedClient) {
     super([
@@ -53,7 +53,7 @@ class PresenceTemplater extends Templater {
     this.client = client;
   }
 
-  public get(key: string): string {
+  public get(key: string): Promise<string> {
     switch (key) {
       case 'num_guilds':
         return this.getNumberOfGuilds();
@@ -74,96 +74,116 @@ class PresenceTemplater extends Templater {
       case 'num_commands':
         return this.getNumberOfCommands();
       default:
-        throw new Error('Unknown key inserted in PresenceTemplater.');
+        return Promise.reject(new Error('Unknown key inserted in PresenceTemplater.'));
     }
   }
 
   /**
    * Get the number of guilds the client is connected to.
-   * @returns The number of [guilds](https://discord.js.org/#/docs/main/stable/class/Guild).
+   * @returns A promise that resolves to the number of [guilds](https://discord.js.org/#/docs/main/stable/class/Guild).
    */
-  private getNumberOfGuilds(): string {
-    return this.client.guilds.cache.reduce((sum) => sum + 1, 0).toString();
+  private getNumberOfGuilds(): Promise<string> {
+    if (!this.client.shard) {
+      return Promise.resolve(this.client.guilds.cache.size.toString());
+    }
+
+    return this.client.shard.fetchClientValues('guilds.cache.size')
+      .then((results) => {
+        return results.reduce((sum, size) => sum + size, 0).toString();
+      });
   }
 
   /**
    * Get the prefix used by the client.
-   * @returns The client's prefix.
+   * @returns A promise that resolves to the client's prefix.
    */
-  private getPrefix(): string {
-    return this.client.prefix;
+  private getPrefix(): Promise<string> {
+    return Promise.resolve(this.client.prefix);
   }
 
   /**
    * Get the current time in the client's locale.
-   * @returns The current time.
+   * @returns A promise that resolves to the current time.
    */
-  private getCurrentTime(): string {
-    return dayjs(new Date().getTime()).tz().format('hh:mm:ss A');
+  private getCurrentTime(): Promise<string> {
+    return Promise.resolve(dayjs(new Date().getTime()).tz().format('hh:mm:ss A'));
   }
 
   /**
    * Get the owner's name. If no owner is specified then it returns `undefined`.
-   * @returns The owner's name.
+   * @returns A promise that resolves to the owner's name.
    */
-  private getOwnerName(): string {
-    return this.client.owner?.username || 'undefined';
+  private getOwnerName(): Promise<string> {
+    return Promise.resolve(this.client.owner?.username || 'undefined');
   }
 
   /**
-   * Get the client's name. If the client's user is not ready yet then it returns `undefined`.
-   * @returns The client's name.
+   * Get the client's name. If the client's user is not ready yet, then it returns `undefined`.
+   * @returns A promise that resolves to the client's name.
    */
-  private getClientName(): string {
-    return this.client.user?.username || 'undefined';
+  private getClientName(): Promise<string> {
+    return Promise.resolve(this.client.user?.username || 'undefined');
   }
 
   /**
    * Get the client's uptime since last ready event emitted in a human-readable shape.
    * Returns `null` if no uptime is available.
-   * @returns The client's uptime.
+   * @returns A promise that resolves to the client's uptime.
    */
-  private getUptime(): string {
+  private getUptime(): Promise<string> {
     if (!this.client.uptime) {
-      return 'null';
+      return Promise.resolve('null');
     }
 
-    return humanizeDuration(this.client.uptime, {
+    const uptime = humanizeDuration(this.client.uptime, {
       largest: 3,
       units: ['d', 'h', 'm'],
       round: true,
       conjunction: ' and ',
       serialComma: false
     });
+
+    return Promise.resolve(uptime);
   }
 
   /**
-   * Get the client's time at which the last ready event was emitted. Returns `null`
+   * Get the client's time at which the last ready event was emitted. Returns `null`
    * if no `readyAt` timestamp is available.
-   * @returns The time the client has gone ready.
+   * @returns A promise that resolves to the time the client has gone ready.
    */
-  private getReadyTime(): string {
+  private getReadyTime(): Promise<string> {
     if (!this.client.readyTimestamp) {
-      return 'null';
+      return Promise.resolve('null');
     }
 
-    return dayjs(this.client.readyTimestamp).tz().format('ddd, DD/MM/YY @HH:MM:A');
+    return Promise.resolve(dayjs(this.client.readyTimestamp).tz().format('ddd, DD/MM/YY @HH:MM:A'));
   }
 
   /**
    * Get the total number of members across all the guilds that the client is connected to.
-   * @returns The number of [members](https://discord.js.org/#/docs/main/stable/class/GuildMember).
+   * @returns A promise that resolves to the number of [members](https://discord.js.org/#/docs/main/stable/class/GuildMember).
    */
-  private getNumberOfMembers(): string {
-    return this.client.guilds.cache.reduce((sum, guild) => sum + guild.memberCount, 0).toString();
+  private getNumberOfMembers(): Promise<string> {
+    if (!this.client.shard) {
+      return Promise.resolve(this.client.guilds.cache.reduce((sum, guild) => sum + guild.memberCount, 0).toString());
+    }
+
+    return this.client.shard.fetchClientValues('guilds.cache')
+      .then((results) => {
+        return results.reduce((sum, guildCache) => {
+          const memberCounts = guildCache.reduce((sum: number, guild: Discord.Guild) => sum + guild.memberCount, 0);
+
+          return sum + memberCounts;
+        }, 0).toString();
+      });
   }
 
   /**
    * Get the number of commands registered to this client.
-   * @returns The number of commands.
+   * @returns A promise that resolves to the number of commands.
    */
-  private getNumberOfCommands(): string {
-    return this.client.registry.commands.reduce((sum) => sum + 1, 0).toString();
+  private getNumberOfCommands(): Promise<string> {
+    return Promise.resolve(this.client.registry.commands.size.toString());
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import ExtendedClient from './classes/ExtendedClient';
 import ClientDefaultHandlers from './classes/events/ClientDefaultHandlers';
 import ExtraClientDefaultHandlers from './classes/events/ExtraClientDefaultHandlers';
 import Templater from './classes/abstract/Templater';
+import AsyncTemplater from './classes/abstract/AsyncTemplater';
 import PresenceTemplater from './classes/presence/PresenceTemplater';
 import PresenceManager from './classes/presence/PresenceManager';
 import ConfigProvider from './classes/config/ConfigProvider';
@@ -32,6 +33,7 @@ export {
   ClientDefaultHandlers,
   ExtraClientDefaultHandlers,
   Templater,
+  AsyncTemplater,
   PresenceTemplater,
   PresenceManager,
   ConfigProvider,

--- a/test/classes/abstract/AsyncTemplater.spec.ts
+++ b/test/classes/abstract/AsyncTemplater.spec.ts
@@ -1,0 +1,39 @@
+import AsyncTemplater from '../../../src/classes/abstract/AsyncTemplater';
+
+class ConcreteAsyncTemplater extends AsyncTemplater {
+  public get(): Promise<string> {
+    return Promise.resolve('value');
+  }
+}
+
+describe('Classes: Abstract: Templater', () => {
+  let asyncTemplater: AsyncTemplater;
+
+  beforeEach(() => {
+    asyncTemplater = new ConcreteAsyncTemplater(['key']);
+  });
+
+  describe('apply()', () => {
+    it('should resolve the same string if no templates are included.', async() => {
+      const str = 'This is a regular string.';
+
+      expect(await asyncTemplater.apply(str)).toBe(str);
+    });
+
+    it('should resolve the template on all occurrences.', async() => {
+      const template = 'This {key} is a {key} template.';
+      const expected = 'This value is a value template.';
+
+      expect(await asyncTemplater.apply(template)).toBe(expected);
+    });
+
+    it('should not call get if no templates are included.', async() => {
+      const str = 'This is a regular string.';
+      const getSpy = jest.spyOn(asyncTemplater, 'get');
+
+      await asyncTemplater.apply(str);
+
+      expect(getSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/classes/abstract/Templater.spec.ts
+++ b/test/classes/abstract/Templater.spec.ts
@@ -16,15 +16,24 @@ describe('Classes: Abstract: Templater', () => {
   describe('apply()', () => {
     it('should return the same string if no templates are included.', () => {
       const str = 'This is a regular string.';
-      
+
       expect(templater.apply(str)).toBe(str);
     });
 
     it('should apply the template on all occurrences.', () => {
       const template = 'This {key} is a {key} template.';
       const expected = 'This value is a value template.';
-      
+
       expect(templater.apply(template)).toBe(expected);
+    });
+
+    it('should not call get if no templates are included.', () => {
+      const str = 'This is a regular string.';
+      const getSpy = jest.spyOn(templater, 'get');
+
+      templater.apply(str);
+
+      expect(getSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/classes/command/CommandRegistry.spec.ts
+++ b/test/classes/command/CommandRegistry.spec.ts
@@ -77,7 +77,30 @@ describe('Classes: Command: CommandRegistry', () => {
       }).toThrow();
     });
 
-    it('should throw if command is already registered.', () => {
+    it('should throw if command is already registered by name.', () => {
+      expect(() => {
+        registry.registerCommand(command);
+      }).toThrow();
+    });
+
+    it('should throw if command is already registered by alias.', () => {
+      const command1 = new ConcreteCommand(clientMock, { name: 'cmd', aliases: ['commando'] });
+      const command2 = new ConcreteCommand(clientMock, { name: 'cmd2', aliases: ['cm3', 'cmd'] });
+      const command3 = new ConcreteCommand(clientMock, { name: 'cmd3', aliases: ['commando'] });
+
+      registry.registerCommand(command1);
+
+      expect(() => {
+        registry.registerCommand(command2);
+      }).toThrow();
+      expect(() => {
+        registry.registerCommand(command3);
+      }).toThrow();
+    });
+
+    it('should throw if command aliases contain command name.', () => {
+      const command = new ConcreteCommand(clientMock, { name: 'cmd', aliases: ['cm3', 'cmd'] });
+
       expect(() => {
         registry.registerCommand(command);
       }).toThrow();

--- a/test/classes/presence/PresenceManager.spec.ts
+++ b/test/classes/presence/PresenceManager.spec.ts
@@ -132,10 +132,12 @@ describe('Classes: Presence: PresenceManager', () => {
       expect(clearIntervalSpy).toHaveBeenCalledWith(oldHandle);
     });
 
-    it('should update presence when interval hits.', () => {
+    it('should update presence when interval hits.', async() => {
+      const updateSpy = jest.spyOn(manager, 'update');
+
       manager.setRefreshInterval(1000);
       jest.advanceTimersToNextTimer();
-      expect(mockedTemplates).toContain(setPresenceSpy.mock.calls[0][0].activity.name);
+      expect(updateSpy).toHaveBeenCalledTimes(2); // Initial + Timer.
     });
 
     it('should emit a presenceRefreshInterval event when refreshInterval has been removed.', () => {

--- a/test/classes/presence/PresenceTemplater.spec.ts
+++ b/test/classes/presence/PresenceTemplater.spec.ts
@@ -1,71 +1,94 @@
 import dayjs from 'dayjs';
+import Discord from 'discord.js';
 import PresenceTemplater from '../../../src/classes/presence/PresenceTemplater';
 import ExtendedClient from '../../../src/classes/ExtendedClient';
 import ConcreteCommand from '../../../__mocks__/command';
 
-dayjs.tz.setDefault('Europe/Paris');
+jest.mock('discord.js');
 
-const clientMock = new ExtendedClient({ prefix: '?', owner: '123' });
+dayjs.tz.setDefault('Europe/Paris');
 
 const dateToLocaleTimeStringSpy = jest.spyOn(Date.prototype, 'getTime');
 
 describe('Classes: Presence: PresenceTemplater', () => {
   let templater: PresenceTemplater;
+  let clientMock: ExtendedClient;
 
   beforeAll(() => {
     dateToLocaleTimeStringSpy.mockReturnValue(1293872389);
-    
+  });
+
+  beforeEach(() => {
+    clientMock = new ExtendedClient({ prefix: '?', owner: '123' });
+    templater = new PresenceTemplater(clientMock);
+
     for (let i = 0; i < 3; i++) {
       const command = new ConcreteCommand(clientMock, { name: Math.random().toString() });
       clientMock.registry.commands.set(command.name, command);
     }
   });
 
-  beforeEach(() => {
-    templater = new PresenceTemplater(clientMock);
-  });
-
   describe('get()', () => {
-    it('should throw if an unknown key is specified.', () => {
-      expect(() => {
-        templater.get('unknown');
-      }).toThrow();
+    it('should reject if an unknown key is specified.', () => {
+      expect.assertions(1);
+
+      return templater.get('unknown')
+        .catch((err) => {
+          expect(err).toBeInstanceOf(Error);
+        });
     });
 
-    it('should return the string for key: num_guilds.', () => {
-      expect(templater.get('num_guilds')).toBe('3');
+    it('should return the string for key: num_guilds.', async() => {
+      expect(await templater.get('num_guilds')).toBe('3');
     });
 
-    it('should return the string for key: prefix.', () => {
-      expect(templater.get('prefix')).toBe('?');
+    it('should return the string for key: num_guilds for a sharded client.', async() => {
+      clientMock.shard = new Discord.ShardClientUtil(clientMock, 'worker');
+      const fetchMock = clientMock.shard.fetchClientValues as jest.Mock;
+      fetchMock.mockResolvedValue([3, 3, 1]);
+
+      expect(await templater.get('num_guilds')).toBe('7');
     });
 
-    it('should return the string for key: cur_time.', () => {
-      expect(templater.get('cur_time')).toBe('12:24:32 AM');
+    it('should return the string for key: prefix.', async() => {
+      expect(await templater.get('prefix')).toBe('?');
     });
 
-    it('should return the string for key: owner_name.', () => {
-      expect(templater.get('owner_name')).toBe('owner');
+    it('should return the string for key: cur_time.', async() => {
+      expect(await templater.get('cur_time')).toBe('12:24:32 AM');
     });
 
-    it('should return the string for key: client_name.', () => {
-      expect(templater.get('client_name')).toBe('client');
+    it('should return the string for key: owner_name.', async() => {
+      expect(await templater.get('owner_name')).toBe('owner');
     });
 
-    it('should return the string for key: uptime.', () => {
-      expect(templater.get('uptime')).toBe('177 days, 13 hours and 27 minutes');
+    it('should return the string for key: client_name.', async() => {
+      expect(await templater.get('client_name')).toBe('client');
     });
 
-    it('should return the string for key: ready_time.', () => {
-      expect(templater.get('ready_time')).toBe('Mon, 14/08/71 @05:08:AM');
+    it('should return the string for key: uptime.', async() => {
+      expect(await templater.get('uptime')).toBe('177 days, 13 hours and 27 minutes');
     });
 
-    it('should return the string for key: num_members.', () => {
-      expect(templater.get('num_members')).toBe('17');
+    it('should return the string for key: ready_time.', async() => {
+      expect(await templater.get('ready_time')).toBe('Mon, 14/08/71 @05:08:AM');
     });
 
-    it('should return the string for key: num_commands.', () => {
-      expect(templater.get('num_commands')).toBe('3');
+    it('should return the string for key: num_members.', async() => {
+      expect(await templater.get('num_members')).toBe('17');
+    });
+
+    it('should return the string for key: num_members for a sharded client.', async() => {
+      clientMock.shard = new Discord.ShardClientUtil(clientMock, 'worker');
+      const fetchMock = clientMock.shard.fetchClientValues as jest.Mock;
+      fetchMock.mockResolvedValue([clientMock.guilds.cache, clientMock.guilds.cache, clientMock.guilds.cache]);
+
+      const expected = clientMock.guilds.cache.reduce((s, g) => s + g.memberCount, 0) * 3;
+      expect(await templater.get('num_members')).toBe(expected.toString());
+    });
+
+    it('should return the string for key: num_commands.', async() => {
+      expect(await templater.get('num_commands')).toBe('3');
     });
   });
 });


### PR DESCRIPTION
### :page_facing_up: Description

This PR corresponds to the version 1.2.1 of this package. It includes the following changes:

- Fixed a bug where a command could be registered despite its alias being part of another command's aliases.
- Fixed a bug where a command could be registered despite one of its alias being its own name.
- Fixed a bug where `PresenceTemplater` would return the wrong values for `num_guilds` and `num_members` if the client was sharded.
- Fixed a bug where `PresenceTemplater` would get all the available values for its keys despite the given string not containing any of them.

