### PR TITLE
Feature/config validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ npm install discord.js @greencoast/discord.js-extended
 
 This package covers client configuration from environment variables and/or JSON files through the [ConfigProvider](https://docs.greencoaststudios.com/discord.js-extended/master/classes/discord_js_extended.configprovider.html) class, which makes it easy to add configuration to a bot. Consider checking the [documentation page](https://docs.greencoaststudios.com/discord.js-extended/master/classes/discord_js_extended.configprovider.html) to see how to use this.
 
+You may also specify custom validators for even more control of how config is provided to your bot. Simply, pass a `customValidators` property to the `ConfigProvider` options, and map the key of the config to its validator function. Your validator function should
+throw a `TypeError` if the given value is invalid based on your criteria.
+
 An example of a bot's configuration may be as follows:
 
 ```js
@@ -47,13 +50,23 @@ const config = new ConfigProvider({
     PREFIX: '!', // Adds a default value for the PREFIX config.
     TOKEN: null, // Adds a default value for the TOKEN config.
     MY_ID: 123,
-    OPTIONAL_FLAG: false
+    OPTIONAL_FLAG: false,
+    MY_ENUM: 'enum1'
   },
   types: { // These are the types of the configuration. The provider validates that the config receives the proper configuration types.
     PREFIX: 'string',
     TOKEN: ['string', 'null'], // With a 'null' type, you can pass 'null' to have it as null.
     MY_ID: 'number',
-    OPTIONAL_FLAG: ['boolean', 'null']
+    OPTIONAL_FLAG: ['boolean', 'null'],
+    MY_ENUM: 'string'
+  },
+  customValidators: { // These are the custom validators to use instead of the basic type based validator.
+    MY_ENUM: (value) => {
+      const validValues = ['enum1', 'enum2', 'enum3'];
+      if (!validValues.includes(value)) {
+        throw new TypeError(`${value} is not a valid value for MY_ENUM, you should use: ${validValues.join(', ')}`);
+      }
+    }
   }
 });
 

--- a/example/config/settings.json
+++ b/example/config/settings.json
@@ -1,3 +1,4 @@
 {
-  "prefix": "$"
+  "prefix": "$",
+  "my_enum": "enum1"
 }

--- a/example/index.js
+++ b/example/index.js
@@ -11,13 +11,23 @@ const config = new ConfigProvider({
   configPath: path.join(__dirname, './config/settings.json'),
   default: {
     PREFIX: '!',
-    OPTIONAL_NUMBER: null
+    OPTIONAL_NUMBER: null,
+    MY_ENUM: 'enum1'
   },
   types: {
     TOKEN: 'string',
     PREFIX: 'string',
     OPTIONAL_NUMBER: ['number', 'null'], // A DISCORD_OPTIONAL_NUMBER env variable which will be cast to a number. It also accepts "null" as value.
-    REQUIRED_BOOLEAN: 'boolean' // A DISCORD_REQUIRED_BOOLEAN env variable which will be cast to a boolean.
+    REQUIRED_BOOLEAN: 'boolean', // A DISCORD_REQUIRED_BOOLEAN env variable which will be cast to a boolean.
+    MY_ENUM: 'string' // A DISCORD_MY_ENUM env variable that will use a custom validator.
+  },
+  customValidators: {
+    MY_ENUM: (value) => {
+      const validValues = ['enum1', 'enum2', 'enum3'];
+      if (!validValues.includes(value)) {
+        throw new TypeError(`${value} is not a valid value for MY_ENUM, you should use: ${validValues.join(', ')}`);
+      }
+    }
   }
 });
 

--- a/src/classes/config/ConfigProvider.ts
+++ b/src/classes/config/ConfigProvider.ts
@@ -89,7 +89,7 @@ class ConfigProvider {
     this.options = options;
     this.default = options.default;
     this.config = {};
-    this.validator = new ConfigValidator(options.types || {});
+    this.validator = new ConfigValidator(options.types || {}, options.customValidators || {});
 
     this.processDefaults(options.default);
     this.processConfigFile(options.configPath);

--- a/src/classes/config/ConfigValidator.ts
+++ b/src/classes/config/ConfigValidator.ts
@@ -1,4 +1,4 @@
-import { ConfigValue } from '../../types';
+import { ConfigValue, ConfigCustomValidators } from '../../types';
 
 /**
  * A validator class for the configuration provider. This class receives an object
@@ -40,12 +40,25 @@ class ConfigValidator {
   public types: Record<string, string | string[]>;
 
   /**
-   * @param types The types for this config validator.
+   * An object that maps a config key to a custom validator function.
+   * This validator function will be used to validate the config supplied.
+   * It will skip the default type validator and instead use the one specified here.
+   * This function should not return anything, but throw a TypeError if the given value is not
+   * correct.
+   * @type {ConfigCustomValidators}
+   * @memberof ConfigValidator
    */
-  constructor(types: Record<string, string | string[]>) {
+  public customValidators: ConfigCustomValidators;
+
+  /**
+   * @param types The types for this config validator.
+   * @param customValidators An object that maps a config key to a custom validator function.
+   */
+  constructor(types: Record<string, string | string[]>, customValidators: ConfigCustomValidators = {}) {
     this.validateTypes(types);
 
     this.types = types;
+    this.customValidators = customValidators;
   }
 
   /**

--- a/src/classes/config/ConfigValidator.ts
+++ b/src/classes/config/ConfigValidator.ts
@@ -12,6 +12,12 @@ import { ConfigValue, ConfigCustomValidators } from '../../types';
  * it will be defaulted to `string`. Keep this in mind in the case you need to have
  * a boolean or a number in your configuration.
  *
+ * You may also specify custom validators by passing an object that maps the key of the config
+ * with its validator. This validator function does not need to return anything, but throw a
+ * TypeError if the given value in its parameter is not valid according to your criteria.
+ * If you pass a customValidator for a specific key, you should still pass its type because
+ * it is used to cast the value coming from environment variables, since they're only strings.
+ *
  * This configuration is most useful for configuration coming from env variables
  * since they are only strings. Although, in a case where only a JSON configuration is
  * specified, you may run into trouble if you don't specify the types for those settings

--- a/src/classes/config/ConfigValidator.ts
+++ b/src/classes/config/ConfigValidator.ts
@@ -70,6 +70,12 @@ class ConfigValidator {
   public validate(config: Record<string, ConfigValue>): void {
     Object.keys(config).forEach((key) => {
       const value = config[key];
+
+      const customValidator = this.customValidators[key];
+      if (customValidator) {
+        return customValidator(value);
+      }
+
       const type = this.types[key] || 'string';
 
       if (Array.isArray(type)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import ConfigProviderOptions from './interfaces/ConfigProviderOptions';
 import CommandInfo from './interfaces/CommandInfo';
 import SlashCommandInfo from './interfaces/SlashCommandInfo';
 
-import { ConfigValue, CommandTrigger, PresenceTemplaterGetters } from './types';
+import { ConfigValue, ConfigCustomValidators, CommandTrigger, PresenceTemplaterGetters } from './types';
 
 export {
   ExtendedClient,
@@ -61,6 +61,7 @@ export {
   CommandInfo,
   SlashCommandInfo,
   ConfigValue,
+  ConfigCustomValidators,
   CommandTrigger,
   PresenceTemplaterGetters
 };

--- a/src/interfaces/ConfigProviderOptions.ts
+++ b/src/interfaces/ConfigProviderOptions.ts
@@ -1,4 +1,4 @@
-import { ConfigValue } from '../types';
+import { ConfigCustomValidators, ConfigValue } from '../types';
 
 /**
  * The config provider's options object. This defines where the config will be pulled from
@@ -29,7 +29,16 @@ interface ConfigProviderOptions {
    * It can be a string or an array of strings.
    * Types can be: `boolean`, `number`, `string`, or `null`.
    */
-  types?: Record<string, string | string[]>
+  types?: Record<string, string | string[]>,
+
+  /**
+   * An object that maps a config key to a custom validator function.
+   * This validator function will be used to validate the config supplied.
+   * It will skip the default type validator and instead use the one specified here.
+   * This function should not return anything, but throw a TypeError if the given value is not
+   * correct.
+   */
+  customValidators?: ConfigCustomValidators
 }
 
 export default ConfigProviderOptions;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 import Discord from 'discord.js';
 
 export type ConfigValue = string | boolean | null | number;
-export type ConfigCustomValidators = Record<string, (value: string) => void>;
+export type ConfigCustomValidators = Record<string, (value: ConfigValue) => void>;
 
 export type CommandTrigger = Discord.Message | Discord.CommandInteraction;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 import Discord from 'discord.js';
 
 export type ConfigValue = string | boolean | null | number;
+export type ConfigCustomValidators = Record<string, (value: string) => void>;
 
 export type CommandTrigger = Discord.Message | Discord.CommandInteraction;
 

--- a/test/classes/config/ConfigValidator.spec.ts
+++ b/test/classes/config/ConfigValidator.spec.ts
@@ -82,6 +82,36 @@ describe('Classes: Config: ConfigValidator', () => {
         validator.validate({ NULLABLE: null });
       }).not.toThrow();
     });
+
+    it('should throw if value does not conform custom validator.', () => {
+      // Type for CUSTOM is ignored with a custom validator.
+      validator = new ConfigValidator({ CUSTOM: 'number' }, {
+        CUSTOM: (value) => {
+          if (value !== 'my_enum') {
+            throw new TypeError('Invalid value for key CUSTOM');
+          }
+        }
+      });
+
+      expect(() => {
+        validator.validate({ CUSTOM: 'invalid' });
+      }).toThrow(TypeError);
+    });
+
+    it('should not throw if value does conform custom validator.', () => {
+      // Type for CUSTOM is ignored with a custom validator.
+      validator = new ConfigValidator({ CUSTOM: 'number' }, {
+        CUSTOM: (value) => {
+          if (value !== 'my_enum') {
+            throw new TypeError('Invalid value for key CUSTOM');
+          }
+        }
+      });
+
+      expect(() => {
+        validator.validate({ CUSTOM: 'my_enum' });
+      }).not.toThrow(TypeError);
+    });
   });
 
   describe('castFromString()', () => {

--- a/test/classes/config/ConfigValidator.spec.ts
+++ b/test/classes/config/ConfigValidator.spec.ts
@@ -84,8 +84,7 @@ describe('Classes: Config: ConfigValidator', () => {
     });
 
     it('should throw if value does not conform custom validator.', () => {
-      // Type for CUSTOM is ignored with a custom validator.
-      validator = new ConfigValidator({ CUSTOM: 'number' }, {
+      validator = new ConfigValidator({ CUSTOM: 'string' }, {
         CUSTOM: (value) => {
           if (value !== 'my_enum') {
             throw new TypeError('Invalid value for key CUSTOM');
@@ -99,8 +98,7 @@ describe('Classes: Config: ConfigValidator', () => {
     });
 
     it('should not throw if value does conform custom validator.', () => {
-      // Type for CUSTOM is ignored with a custom validator.
-      validator = new ConfigValidator({ CUSTOM: 'number' }, {
+      validator = new ConfigValidator({ CUSTOM: 'string' }, {
         CUSTOM: (value) => {
           if (value !== 'my_enum') {
             throw new TypeError('Invalid value for key CUSTOM');


### PR DESCRIPTION
### :pencil: Checklist

Make sure that your PR fulfills these requirements:

- [x] Tests have been added for this feature.
- [x] Code is properly documented.
- [x] All tests pass on your local machine.
- [x] Code has been linted with the proper rules.
- [x] I have added the correct assignees for code review.

### :page_facing_up: Description

This PR adds support for custom validators for a given config key in ConfigProvider. Simply pass an object that maps the key of the config to its validator. A validator function should throw a `TypeError` if the value is not valid according to your criteria.

### :pushpin: Does this PR address any issue?

#27
