### PR TITLE
Feature/config arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ const config = new ConfigProvider({
     TOKEN: ['string', 'null'], // With a 'null' type, you can pass 'null' to have it as null.
     MY_ID: 'number',
     OPTIONAL_FLAG: ['boolean', 'null'],
-    MY_ENUM: 'string'
+    MY_ENUM: 'string',
+    MY_NUM_ARRAY: 'number[]' // You can pass arrays through JSON or comma-separated values through env variables.
   },
   customValidators: { // These are the custom validators to use instead of the basic type based validator.
     MY_ENUM: (value) => {

--- a/example/index.js
+++ b/example/index.js
@@ -19,7 +19,8 @@ const config = new ConfigProvider({
     PREFIX: 'string',
     OPTIONAL_NUMBER: ['number', 'null'], // A DISCORD_OPTIONAL_NUMBER env variable which will be cast to a number. It also accepts "null" as value.
     REQUIRED_BOOLEAN: 'boolean', // A DISCORD_REQUIRED_BOOLEAN env variable which will be cast to a boolean.
-    MY_ENUM: 'string' // A DISCORD_MY_ENUM env variable that will use a custom validator.
+    MY_ENUM: 'string', // A DISCORD_MY_ENUM env variable that will use a custom validator.
+    MY_NUM_ARRAY: 'number[]' // A DISCORD_MY_NUM_ARRAY env variable with comma separated numbers that will turn into an array of numbers.
   },
   customValidators: {
     MY_ENUM: (value) => {
@@ -68,6 +69,8 @@ client.on('ready', async() => {
 
   await client.setDataProvider(dataProvider); // It would be recommended to set the data provider once the client is ready.
   await client.deployer.deployToTestingGuild(); // Deploy slash commands to the testing guild.
+
+  logger.info(`My numbers from the environment variable are: ${client.config.get('MY_NUM_ARRAY').join(', ')}`);
 });
 
 client.login(client.config.get('TOKEN'));

--- a/src/classes/config/ConfigProvider.ts
+++ b/src/classes/config/ConfigProvider.ts
@@ -19,11 +19,18 @@ import { ConfigValue } from '../../types';
  *
  * > If config is repeated on multiple sources, they'll be overwritten by the latest config source.
  *
+ * The ConfigProvider supports array types, you can supply them through the JSON config as a direct array
+ * or through environment variables through comma-separated values.
+ *
+ * > Comma escaping is not supported yet, so if you specify a type of `string[]` and insert the value `Hi, my name is.`,
+ * > the value will correspond to `['Hi', ' my name is.']`.
+ *
  * An example environment variable file would be:
  *
  * ```text
  * DISCORD_TOKEN=MY_TOKEN
  * DISCORD_MY_VARIABLE=$
+ * DISCORD_MY_NUMS=123,234,345
  * ```
  *
  * An example JSON config file would be:
@@ -31,7 +38,8 @@ import { ConfigValue } from '../../types';
  * ```json
  * {
  *   "token": "MY_TOKEN",
- *   "my_variable": "$"
+ *   "my_variable": "$",
+ *   "my_nums": [123, 234, 345]
  * }
  * ```
  *
@@ -40,7 +48,8 @@ import { ConfigValue } from '../../types';
  * ```js
  * {
  *   TOKEN: 'MY_TOKEN',
- *   MY_VARIABLE: '$'
+ *   MY_VARIABLE: '$',
+ *   MY_NUMS: [1, 2, 3]
  * }
  * ```
  *
@@ -49,6 +58,7 @@ import { ConfigValue } from '../../types';
  * ```js
  * const token = client.config.get('TOKEN');
  * const myVariable = client.config.get('MY_VARIABLE');
+ * const myNums = client.config.get('MY_NUMS');
  * ```
  *
  * It is also recommended specifying the types of the config. Check {@link ConfigValidator} for more information.

--- a/src/classes/config/ConfigProvider.ts
+++ b/src/classes/config/ConfigProvider.ts
@@ -94,6 +94,7 @@ class ConfigProvider {
 
   /**
    * @param options The options for this config provider.
+   * @throws Throws if it is not possible to cast a value to its given type.
    */
   constructor(options: ConfigProviderOptions = {}) {
     this.options = options;
@@ -151,6 +152,7 @@ class ConfigProvider {
    * Process the environment variables object for configuration.
    * Keys must begin with DISCORD_ to be added to the configuration provider.
    * @param env The environment variables object.
+   * @throws Throws if it is not possible to cast a value to its given type.
    */
   private processEnv(env?: Record<string, ConfigValue>): void {
     if (!env) {

--- a/src/classes/config/ConfigValidator.ts
+++ b/src/classes/config/ConfigValidator.ts
@@ -5,7 +5,8 @@ import { ConfigValue, ConfigCustomValidators } from '../../types';
  * with a subset of the keys of the config with a type or array of types corresponding
  * to that config value.
  *
- * Valid types include: `boolean`, `number`, `string` and `null`.
+ * Valid types include: `boolean`, `number`, `string` and `null`,
+ * or including their array types: `boolean[]`, `number[]` and `string[]`
  * You can set a type to be an array containing multiple of the ones above.
  *
  * It is preferable to specify all the types for your config. However, if a type is omitted
@@ -35,7 +36,10 @@ class ConfigValidator {
     'boolean',
     'number',
     'string',
-    'null'
+    'null',
+    'boolean[]',
+    'number[]',
+    'string[]'
   ];
 
   /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 import Discord from 'discord.js';
 
-export type ConfigValue = string | boolean | null | number;
+export type ConfigValue = string | boolean | null | number | string[] | boolean[] | number[];
 export type ConfigCustomValidators = Record<string, (value: ConfigValue) => void>;
 
 export type CommandTrigger = Discord.Message | Discord.CommandInteraction;

--- a/test/classes/config/ConfigValidator.spec.ts
+++ b/test/classes/config/ConfigValidator.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import ConfigValidator from '../../../src/classes/config/ConfigValidator';
 
 const mockedConfig = {
@@ -140,19 +141,103 @@ describe('Classes: Config: ConfigValidator', () => {
         expect(casted.S).toBe('123');
       });
 
-      it('should keep the value as a string if type contains string.', () => {
-        const validator = new ConfigValidator({ S: ['number', 'string'] });
+      it('should cast to null if the value is null and the type contains string and null.', () => {
+        const validator1 = new ConfigValidator({ N: ['string', 'null'] });
+        const validator2 = new ConfigValidator({ N: ['null', 'string'] });
 
-        const casted = validator.castFromString({ S: '123' });
-        expect(typeof casted.S).toBe('string');
-        expect(casted.S).toBe('123');
+        const casted1 = validator1.castFromString({ N: 'null' });
+        const casted2 = validator2.castFromString({ N: 'null' });
+
+        expect(casted1.N).toBeNull();
+        expect(casted2.N).toBeNull();
       });
 
-      it('should cast to null if the value is null and the type contains string and null.', () => {
-        const validator = new ConfigValidator({ N: ['string', 'null'] });
+      it('should cast to boolean if it is a valid boolean string and the type contains boolean.', () => {
+        const validator1 = new ConfigValidator({ B: ['string', 'boolean'] });
+        const validator2 = new ConfigValidator({ B: ['boolean', 'string'] });
 
-        const casted = validator.castFromString({ N: 'null' });
-        expect(casted.N).toBeNull();
+        const casted1 = validator1.castFromString({ B: 'true' });
+        const casted2 = validator2.castFromString({ B: 'false' });
+
+        expect(casted1.B).toBe(true);
+        expect(casted2.B).toBe(false);
+      });
+
+      it('should return the value if it is an invalid boolean string and the type contains boolean.', () => {
+        const validator1 = new ConfigValidator({ B: ['string', 'boolean'] });
+        const validator2 = new ConfigValidator({ B: ['boolean', 'string'] });
+
+        const casted1 = validator1.castFromString({ B: 'truthy' });
+        const casted2 = validator2.castFromString({ B: 'truthy' });
+
+        expect(casted1.B).toBe('truthy');
+        expect(casted2.B).toBe('truthy');
+      });
+
+      it('should return the value if it is an invalid number string and the type contains number.', () => {
+        const validator1 = new ConfigValidator({ N: ['string', 'number'] });
+        const validator2 = new ConfigValidator({ N: ['number', 'string'] });
+
+        const casted1 = validator1.castFromString({ N: '123.213.21' });
+        const casted2 = validator2.castFromString({ N: '123.213.21' });
+
+        expect(casted1.N).toBe('123.213.21');
+        expect(casted2.N).toBe('123.213.21');
+      });
+
+      it('should cast to number if it is a valid number string and the type contains number.', () => {
+        const validator1 = new ConfigValidator({ N: ['string', 'number'] });
+        const validator2 = new ConfigValidator({ N: ['number', 'string'] });
+
+        const casted1 = validator1.castFromString({ N: '3.14' });
+        const casted2 = validator2.castFromString({ N: '42' });
+
+        expect(casted1.N).toBe(3.14);
+        expect(casted2.N).toBe(42);
+      });
+
+      it('should return the value if it is an invalid number[] string and the type contains number[].', () => {
+        const validator1 = new ConfigValidator({ N: ['string', 'number[]'] });
+        const validator2 = new ConfigValidator({ N: ['number[]', 'string'] });
+
+        const casted1 = validator1.castFromString({ N: '123.213.21,23,23' });
+        const casted2 = validator2.castFromString({ N: '123.213.21,23,23' });
+
+        expect(casted1.N).toBe('123.213.21,23,23');
+        expect(casted2.N).toBe('123.213.21,23,23');
+      });
+
+      it('should cast to number[] if it is a valid number[] string and the type contains number[].', () => {
+        const validator1 = new ConfigValidator({ N: ['string', 'number[]'] });
+        const validator2 = new ConfigValidator({ N: ['number[]', 'string'] });
+
+        const casted1 = validator1.castFromString({ N: '3.14,42,1' });
+        const casted2 = validator2.castFromString({ N: '3.14,42,1' });
+
+        expect(casted1.N as number[]).toStrictEqual([3.14, 42, 1]);
+        expect(casted2.N as number[]).toStrictEqual([3.14, 42, 1]);
+      });
+
+      it('should return the value if it is an invalid boolean[] string and the type contains boolean[].', () => {
+        const validator1 = new ConfigValidator({ B: ['string', 'boolean[]'] });
+        const validator2 = new ConfigValidator({ B: ['boolean[]', 'string'] });
+
+        const casted1 = validator1.castFromString({ B: 'true,false,truthy' });
+        const casted2 = validator2.castFromString({ B: 'true,false,truthy' });
+
+        expect(casted1.B).toBe('true,false,truthy');
+        expect(casted2.B).toBe('true,false,truthy');
+      });
+
+      it('should cast to boolean[] if it is a valid boolean[] string and the type contains boolean[].', () => {
+        const validator1 = new ConfigValidator({ B: ['string', 'boolean[]'] });
+        const validator2 = new ConfigValidator({ B: ['boolean[]', 'string'] });
+
+        const casted1 = validator1.castFromString({ B: 'true,false,true' });
+        const casted2 = validator2.castFromString({ B: 'true,false,true' });
+
+        expect(casted1.B as boolean[]).toStrictEqual([true, false, true]);
+        expect(casted2.B as boolean[]).toStrictEqual([true, false, true]);
       });
     });
 
@@ -161,14 +246,8 @@ describe('Classes: Config: ConfigValidator', () => {
         const validator = new ConfigValidator({ S: 'string[]' });
 
         const casted = validator.castFromString({ S: 'one,two,three' });
-        const s = casted.S as string[];
 
-        s.forEach((val) => {
-          expect(typeof val).toBe('string');
-        });
-        expect(s[0]).toBe('one');
-        expect(s[1]).toBe('two');
-        expect(s[2]).toBe('three');
+        expect(casted.S).toStrictEqual(['one', 'two', 'three']);
       });
     });
 
@@ -183,12 +262,12 @@ describe('Classes: Config: ConfigValidator', () => {
         expect(casted.F).toBe(false);
       });
 
-      it('should keep it as a string if it is not a valid boolean string.', () => {
+      it('should throw if it is not a valid boolean string.', () => {
         const validator = new ConfigValidator({ B: 'boolean' });
 
-        const casted = validator.castFromString({ B: 'truthy' });
-        expect(typeof casted.B).toBe('string');
-        expect(casted.B).toBe('truthy');
+        expect(() => {
+          validator.castFromString({ B: 'truthy' });
+        }).toThrow();
       });
 
       it('should cast the value to a boolean if the type contains boolean and it is a valid boolean string.', () => {
@@ -204,17 +283,17 @@ describe('Classes: Config: ConfigValidator', () => {
         expect(casted2.B).toBe(true);
       });
 
-      it('should not cast the value to a boolean if the type contains boolean and it is not a valid boolean string.', () => {
+      it('should throw if the type contains boolean and it is not a valid boolean string.', () => {
         const validator1 = new ConfigValidator({ B: ['boolean', 'number'] });
         const validator2 = new ConfigValidator({ B: ['number', 'boolean'] });
 
-        const casted1 = validator1.castFromString({ B: 'truthy' });
-        expect(typeof casted1.B).toBe('string');
-        expect(casted1.B).toBe('truthy');
+        expect(() => {
+          validator1.castFromString({ B: 'truthy' });
+        }).toThrow();
 
-        const casted2 = validator2.castFromString({ B: 'truthy' });
-        expect(typeof casted2.B).toBe('string');
-        expect(casted2.B).toBe('truthy');
+        expect(() => {
+          validator2.castFromString({ B: 'truthy' });
+        }).toThrow();
       });
     });
 
@@ -223,14 +302,16 @@ describe('Classes: Config: ConfigValidator', () => {
         const validator = new ConfigValidator({ B: 'boolean[]' });
 
         const casted = validator.castFromString({ B: 'true,false,true' });
-        const b = casted.B as boolean[];
 
-        b.forEach((val) => {
-          expect(typeof val).toBe('boolean');
-        });
-        expect(b[0]).toBe(true);
-        expect(b[1]).toBe(false);
-        expect(b[2]).toBe(true);
+        expect(casted.B).toStrictEqual([true, false, true]);
+      });
+
+      it('should throw if any of the items is not a valid boolean string.', () => {
+        const validator = new ConfigValidator({ B: 'boolean[]' });
+
+        expect(() => {
+          validator.castFromString({ B: 'true,false,truthy' });
+        }).toThrow();
       });
     });
 
@@ -245,12 +326,12 @@ describe('Classes: Config: ConfigValidator', () => {
         expect(casted.F).toBe(3.1415);
       });
 
-      it('should keep it as a string if it is not a valid number string.', () => {
+      it('should throw if it is not a valid number string.', () => {
         const validator = new ConfigValidator({ N: 'number' });
 
-        const casted = validator.castFromString({ N: 'not-a-number' });
-        expect(typeof casted.N).toBe('string');
-        expect(casted.N).toBe('not-a-number');
+        expect(() => {
+          validator.castFromString({ N: 'not-a-number' });
+        }).toThrow();
       });
 
       it('should cast the value to a number if the type contains number and it is a valid number string.', () => {
@@ -266,17 +347,17 @@ describe('Classes: Config: ConfigValidator', () => {
         expect(casted2.N).toBe(42);
       });
 
-      it('should not cast the value to a number if the type contains number and it is not a valid number string.', () => {
+      it('should throw if the type contains number and it is not a valid number string.', () => {
         const validator1 = new ConfigValidator({ N: ['boolean', 'number'] });
         const validator2 = new ConfigValidator({ N: ['number', 'boolean'] });
 
-        const casted1 = validator1.castFromString({ N: 'not-a-number' });
-        expect(typeof casted1.N).toBe('string');
-        expect(casted1.N).toBe('not-a-number');
+        expect(() => {
+          validator1.castFromString({ N: 'not-a-number' });
+        }).toThrow();
 
-        const casted2 = validator2.castFromString({ N: 'not-a-number' });
-        expect(typeof casted2.N).toBe('string');
-        expect(casted2.N).toBe('not-a-number');
+        expect(() => {
+          validator2.castFromString({ N: 'not-a-number' });
+        }).toThrow();
       });
     });
 
@@ -285,14 +366,16 @@ describe('Classes: Config: ConfigValidator', () => {
         const validator = new ConfigValidator({ N: 'number[]' });
 
         const casted = validator.castFromString({ N: '1,2,3' });
-        const n = casted.N as number[];
 
-        n.forEach((val) => {
-          expect(typeof val).toBe('number');
-        });
-        expect(n[0]).toBe(1);
-        expect(n[1]).toBe(2);
-        expect(n[2]).toBe(3);
+        expect(casted.N).toStrictEqual([1, 2, 3]);
+      });
+
+      it('should throw if any of the items is not a valid number string.', () => {
+        const validator = new ConfigValidator({ N: 'number[]' });
+
+        expect(() => {
+          validator.castFromString({ N: '123,223,11.123.1213' });
+        }).toThrow();
       });
     });
 
@@ -304,12 +387,12 @@ describe('Classes: Config: ConfigValidator', () => {
         expect(casted.N).toBeNull();
       });
 
-      it('should keep it as a string if it is not a valid null string.', () => {
+      it('should throw if it is not a valid null string.', () => {
         const validator = new ConfigValidator({ N: 'null' });
 
-        const casted = validator.castFromString({ N: 'not-null' });
-        expect(typeof casted.N).toBe('string');
-        expect(casted.N).toBe('not-null');
+        expect(() => {
+          validator.castFromString({ N: 'not-null' });
+        }).toThrow();
       });
 
       it('should cast the value to a null if the type contains null and it is a valid null string.', () => {
@@ -323,17 +406,17 @@ describe('Classes: Config: ConfigValidator', () => {
         expect(casted2.N).toBeNull();
       });
 
-      it('should not cast the value to a null if the type contains null and it is not a valid null string.', () => {
+      it('should throw if the type contains null and it is not a valid null string.', () => {
         const validator1 = new ConfigValidator({ N: ['null', 'number'] });
         const validator2 = new ConfigValidator({ N: ['number', 'null'] });
 
-        const casted1 = validator1.castFromString({ N: 'not-null' });
-        expect(typeof casted1.N).toBe('string');
-        expect(casted1.N).toBe('not-null');
+        expect(() => {
+          validator1.castFromString({ N: 'not-null' });
+        }).toThrow();
 
-        const casted2 = validator2.castFromString({ N: 'not-null' });
-        expect(typeof casted2.N).toBe('string');
-        expect(casted2.N).toBe('not-null');
+        expect(() => {
+          validator2.castFromString({ N: 'not-null' });
+        }).toThrow();
       });
     });
   });

--- a/test/classes/config/ConfigValidator.spec.ts
+++ b/test/classes/config/ConfigValidator.spec.ts
@@ -5,7 +5,11 @@ const mockedConfig = {
   NUM: 123,
   F: false,
   F_STRING: 'false',
-  NULLABLE: 'optional'
+  NULLABLE: 'optional',
+  STR_ARRAY: ['hi', 'there'],
+  BOOL_ARRAY: [true, false],
+  NUM_ARRAY: [3.14, 42],
+  STR_MUL_SINGLE: ['string here']
 };
 
 const mockedTypes = {
@@ -13,7 +17,11 @@ const mockedTypes = {
   NUM: 'number',
   F: 'boolean',
   F_STRING: ['string', 'boolean'],
-  NULLABLE: ['string', 'null']
+  NULLABLE: ['string', 'null'],
+  STR_ARRAY: 'string[]',
+  BOOL_ARRAY: 'boolean[]',
+  NUM_ARRAY: 'number[]',
+  STR_MUL_SINGLE: ['string', 'string[]']
 };
 
 describe('Classes: Config: ConfigValidator', () => {
@@ -148,6 +156,22 @@ describe('Classes: Config: ConfigValidator', () => {
       });
     });
 
+    describe('With "string[]"', () => {
+      it('should cast every item into a string.', () => {
+        const validator = new ConfigValidator({ S: 'string[]' });
+
+        const casted = validator.castFromString({ S: 'one,two,three' });
+        const s = casted.S as string[];
+
+        s.forEach((val) => {
+          expect(typeof val).toBe('string');
+        });
+        expect(s[0]).toBe('one');
+        expect(s[1]).toBe('two');
+        expect(s[2]).toBe('three');
+      });
+    });
+
     describe('With "boolean"', () => {
       it('should cast the value to a boolean if it is a valid boolean string.', () => {
         const validator = new ConfigValidator({ T: 'boolean', F: 'boolean' });
@@ -194,6 +218,22 @@ describe('Classes: Config: ConfigValidator', () => {
       });
     });
 
+    describe('With "boolean[]"', () => {
+      it('should cast every item into a boolean.', () => {
+        const validator = new ConfigValidator({ B: 'boolean[]' });
+
+        const casted = validator.castFromString({ B: 'true,false,true' });
+        const b = casted.B as boolean[];
+
+        b.forEach((val) => {
+          expect(typeof val).toBe('boolean');
+        });
+        expect(b[0]).toBe(true);
+        expect(b[1]).toBe(false);
+        expect(b[2]).toBe(true);
+      });
+    });
+
     describe('With "number"', () => {
       it('should cast the value to a number if it is a valid number string.', () => {
         const validator = new ConfigValidator({ N: 'number', F: 'number' });
@@ -237,6 +277,22 @@ describe('Classes: Config: ConfigValidator', () => {
         const casted2 = validator2.castFromString({ N: 'not-a-number' });
         expect(typeof casted2.N).toBe('string');
         expect(casted2.N).toBe('not-a-number');
+      });
+    });
+
+    describe('With "number[]"', () => {
+      it('should cast every item into a number.', () => {
+        const validator = new ConfigValidator({ N: 'number[]' });
+
+        const casted = validator.castFromString({ N: '1,2,3' });
+        const n = casted.N as number[];
+
+        n.forEach((val) => {
+          expect(typeof val).toBe('number');
+        });
+        expect(n[0]).toBe(1);
+        expect(n[1]).toBe(2);
+        expect(n[2]).toBe(3);
       });
     });
 


### PR DESCRIPTION
### :pencil: Checklist

Make sure that your PR fulfills these requirements:

- [x] Tests have been added for this feature.
- [x] Code is properly documented.
- [x] All tests pass on your local machine.
- [x] Code has been linted with the proper rules.
- [x] I have added the correct assignees for code review.

### :page_facing_up: Description

This PR adds support for config values that require to be arrays. You can define arrays with the types `string[]`, `boolean[]` and `number[]`. This PR also changes how the casting behaves when casting for types that contain `string` and something else. Before, for the type `[string, number]`, the value would be kept as a string, whereas now, the value will be casted into any other type or be kept as a string if the casting failed.

### :pushpin: Does this PR address any issue?

#42
