### PR TITLE
Feature/i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,83 @@ client.on('ready', () => {
 });
 ```
 
+### Localizing Your Bot
+
+The package contains a [Localizer](https://docs.greencoaststudios.com/discord.js-extended/master/classes/discord_js_extended.localizer.html) class to help with the localization of your bot. In order to use it, you should pass a `localizer` object to your `client` constructor and
+initialize the localizer in the `ready` event.
+
+```js
+const client = new ExtendedClient({
+  localizer: {
+    defaultLocale: 'en', // The default locale for your bot.
+    dataProviderKey: 'locale', // The key to be used to store the locale for each guild in the client's data provider.
+    localeStrings: locales
+  }
+});
+
+client.on('ready', async() => {
+  await client.setDataProvider(new DataProvider()); // Should set the data provider before.
+  await client.localizer.init(); // Initializes the localizer.  
+});
+```
+
+The `localeStrings` object should map the name of the locale to another object that maps the message keys with their corresponding message string in its respective language.
+In the example above, the variable `locales` could be:
+
+```js
+const locales = {
+  en: {
+    'message.test.hello': 'Hello',
+    'message.test.bye': 'Bye',
+    'message.test.with_value': 'Hello {name}!'
+  },
+  es: {
+    'message.test.hello': 'Hola',
+    'message.test.bye': 'Adios',
+    'message.test.with_value': 'Hola {name}!'
+  },
+  fr: {
+    'message.test.hello': 'Bonjour',
+    'message.test.bye': 'Au revoir',
+    'message.test.with_value': 'Bonjour {name}!'
+  }
+};
+```
+
+Locale messages should follow the [ICU format](https://formatjs.io/docs/intl-messageformat/#common-usage-example).
+
+Inside a command, you may use the localizer in the following manner:
+
+```js
+class MyCommand extends SlashCommand {
+  async run(interaction) {
+    const localizer = this.client.localizer.getLocalizer(interaction.guild);
+    
+    interaction.reply(localizer.t('message.test.hello'));
+    interaction.reply(localizer.t('message.test.with_value', { name: 'your name' }));
+  }
+}
+```
+
+This uses the locale saved for the guild. You can change the locale for the guild as such:
+
+```js
+class MyCommand extends SlashCommand {
+  async run(interaction) {
+    const localizer = this.client.localizer.getLocalizer(interaction.guild);
+    
+    await localizer.updateLocale('fr');
+    interaction.reply(`Updated locale to ${localizer.locale}`);
+  }
+}
+```
+
+If you're outside the context of a guild, you can still use the localizer by using:
+
+```js
+client.localizer.t('message.test.with_value', 'es', { name: 'your name' });
+```
+
 ### Creating Commands
 
 The package contains a [RegularCommand](https://docs.greencoaststudios.com/discord.js-extended/master/classes/discord_js_extended.regularcommand.html) to facilitate the creation of commands. In order to create one, you need to create a class that extends RegularCommand and implements a `run()` method.

--- a/__mocks__/discord.js.ts
+++ b/__mocks__/discord.js.ts
@@ -14,5 +14,6 @@ export default {
   MessageEmbed: DiscordMock.MessageEmbedMock,
   ShardClientUtil: DiscordMock.ShardClientUtilMock,
   Interaction: DiscordMock.InteractionMock,
-  Collection: RealDiscord.Collection
+  Collection: RealDiscord.Collection,
+  Permissions: RealDiscord.Permissions
 };

--- a/__mocks__/discordMocks.ts
+++ b/__mocks__/discordMocks.ts
@@ -164,6 +164,7 @@ export class InteractionMock {
   public isCommand: jest.Mock;
   public inGuild: jest.Mock;
   public reply: jest.Mock;
+  public options: unknown;
 
   constructor() {
     this.guild = new GuildMock();
@@ -172,5 +173,8 @@ export class InteractionMock {
     this.isCommand = jest.fn();
     this.inGuild = jest.fn();
     this.reply = jest.fn();
+    this.options = {
+      getString: jest.fn()
+    };
   }
 }

--- a/__mocks__/discordMocks.ts
+++ b/__mocks__/discordMocks.ts
@@ -40,6 +40,9 @@ export class ClientMock {
         reduce: (fn: any, initial: any) => {
           return [{ memberCount: 10 }, { memberCount: 5 }, { memberCount: 2 }].reduce(fn, initial);
         },
+        map: (fn: any) => {
+          return [{ id: '1' }, { id: '2' }, { id: '3' }].map(fn);
+        },
         size: 3
       }
     };

--- a/__mocks__/locale.ts
+++ b/__mocks__/locale.ts
@@ -1,0 +1,17 @@
+export const mockedLocaleStrings = {
+  en: {
+    'message.test.hello': 'Hello',
+    'message.test.bye': 'Bye',
+    'message.test.with_value': 'Hello {name}!'
+  },
+  es: {
+    'message.test.hello': 'Hola',
+    'message.test.bye': 'Adios',
+    'message.test.with_value': 'Hola {name}!'
+  },
+  fr: {
+    'message.test.hello': 'Bonjour',
+    'message.test.bye': 'Au revoir',
+    'message.test.with_value': 'Bonjour {name}!'
+  }
+};

--- a/example/commands/slash/LocalizedSlashCommand.js
+++ b/example/commands/slash/LocalizedSlashCommand.js
@@ -1,0 +1,21 @@
+const { SlashCommand } = require('@greencoast/discord.js-extended');
+const { SlashCommandBuilder } = require('@discordjs/builders');
+
+class LocalizedSlashCommand extends SlashCommand {
+  constructor(client) {
+    super(client, {
+      name: 'localized',
+      description: 'Test localization.',
+      group: 'slash',
+      dataBuilder: new SlashCommandBuilder()
+    });
+  }
+
+  run(interaction) {
+    const localizer = this.client.localizer.getLocalizer(interaction.guild);
+
+    return interaction.reply(localizer.t('greetings.hello', { name: interaction.user.username }));
+  }
+}
+
+module.exports = LocalizedSlashCommand;

--- a/example/index.js
+++ b/example/index.js
@@ -4,6 +4,7 @@ const logger = require('@greencoast/logger');
 const { Intents } = require('discord.js');
 const { ExtendedClient, ConfigProvider } = require('@greencoast/discord.js-extended');
 const LevelDataProvider = require('@greencoast/discord.js-extended/dist/providers/LevelDataProvider').default;
+const locales = require('./locale');
 
 // The environment object contains the property: DISCORD_TOKEN with the bot's token.
 const config = new ConfigProvider({
@@ -48,7 +49,11 @@ const client = new ExtendedClient({
   config,
   errorOwnerReporting: true,
   intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.DIRECT_MESSAGES],
-  testingGuildID: '756628171494916098'
+  testingGuildID: '756628171494916098',
+  localizer: {
+    defaultLocale: 'en',
+    localeStrings: locales
+  }
 });
 
 const dataProvider = new LevelDataProvider(client, path.join(__dirname, './data'));
@@ -68,6 +73,7 @@ client.on('ready', async() => {
   logger.info(`Listening for commands with prefix: ${client.prefix}`);
 
   await client.setDataProvider(dataProvider); // It would be recommended to set the data provider once the client is ready.
+  await client.localizer.init(); // Initialize the localizer after setting up the data provider.
   await client.deployer.deployToTestingGuild(); // Deploy slash commands to the testing guild.
 
   logger.info(`My numbers from the environment variable are: ${client.config.get('MY_NUM_ARRAY').join(', ')}`);

--- a/example/locale/en.js
+++ b/example/locale/en.js
@@ -1,0 +1,15 @@
+const GREETINGS = {
+  'greetings.hello': 'Hello {name}',
+  'greetings.hi': 'Hi!',
+  'greetings.bye': 'Bye',
+  'greetings.goodbye': 'Goodbye!'
+};
+
+const EXTRA = {
+  'extra.nice_weather': "It's {temperature}, it's a nice weather!"
+};
+
+module.exports = {
+  ...GREETINGS,
+  ...EXTRA
+};

--- a/example/locale/es.js
+++ b/example/locale/es.js
@@ -1,0 +1,15 @@
+const GREETINGS = {
+  'greetings.hello': 'Hola {name}',
+  'greetings.hi': '¡Hola!',
+  'greetings.bye': 'Chao',
+  'greetings.goodbye': '¡Adiós!'
+};
+
+const EXTRA = {
+  'extra.nice_weather': "¡La temperatura es de {temperature}, qué buen clima!"
+};
+
+module.exports = {
+  ...GREETINGS,
+  ...EXTRA
+};

--- a/example/locale/index.js
+++ b/example/locale/index.js
@@ -1,0 +1,7 @@
+const en = require('./en');
+const es = require('./es');
+
+module.exports = {
+  en,
+  es
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@greencoast/discord.js-extended",
-      "version": "1.2.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@discordjs/builders": "^0.11.0",
@@ -16,6 +16,7 @@
         "dayjs": "^1.10.7",
         "discord-api-types": "^0.26.1",
         "humanize-duration": "^3.27.1",
+        "intl-messageformat": "^9.11.1",
         "lodash": "^4.17.21",
         "require-all": "^3.0.0"
       },
@@ -684,6 +685,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.1.tgz",
+      "integrity": "sha512-tgtNODZUGuUI6PAcnvaLZpGrZLVkXnnAvgzOiueYMzFdOdcOw4iH1WKhCe3+r6VR8rHKToJ2HksUGNCB+zt/bg==",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "0.2.22",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
+      "integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.16.tgz",
+      "integrity": "sha512-sYg0ImXsAqBbjU/LotoCD9yKC5nUpWVy3s4DwWerHXD4sm62FcjMF8mekwudRk3eZLHqSO+M21MpFUUjDQ+Q5Q==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.1",
+        "@formatjs/icu-skeleton-parser": "1.3.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.3.tgz",
+      "integrity": "sha512-ifWnzjmHPHUF89UpCvClTP66sXYFc8W/qg7Qt+qtTUB9BqRWlFeUsevAzaMYDJsRiOy4S2WJFrJoZgRKUFfPGQ==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.22.tgz",
+      "integrity": "sha512-z+TvbHW8Q/g2l7/PnfUl0mV9gWxV4d0HT6GQyzkO5QI6QjCvCZGiztnmLX7zoyS16uSMvZ2PoMDfSK9xvZkRRA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@greencoast/logger": {
@@ -4738,6 +4783,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.11.1.tgz",
+      "integrity": "sha512-kT0i8AIa1Aez8jGn1i9Xva/sdbjOPY15abR82qnU4jnESjxtynHLW1CBh9ehs13sPA8cE/4A2d6LEne91oDp4w==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.1",
+        "@formatjs/fast-memoize": "1.2.1",
+        "@formatjs/icu-messageformat-parser": "2.0.16",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/is-bigint": {
@@ -9854,6 +9910,50 @@
         }
       }
     },
+    "@formatjs/ecma402-abstract": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.1.tgz",
+      "integrity": "sha512-tgtNODZUGuUI6PAcnvaLZpGrZLVkXnnAvgzOiueYMzFdOdcOw4iH1WKhCe3+r6VR8rHKToJ2HksUGNCB+zt/bg==",
+      "requires": {
+        "@formatjs/intl-localematcher": "0.2.22",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@formatjs/fast-memoize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
+      "integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "@formatjs/icu-messageformat-parser": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.16.tgz",
+      "integrity": "sha512-sYg0ImXsAqBbjU/LotoCD9yKC5nUpWVy3s4DwWerHXD4sm62FcjMF8mekwudRk3eZLHqSO+M21MpFUUjDQ+Q5Q==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.11.1",
+        "@formatjs/icu-skeleton-parser": "1.3.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@formatjs/icu-skeleton-parser": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.3.tgz",
+      "integrity": "sha512-ifWnzjmHPHUF89UpCvClTP66sXYFc8W/qg7Qt+qtTUB9BqRWlFeUsevAzaMYDJsRiOy4S2WJFrJoZgRKUFfPGQ==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.11.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@formatjs/intl-localematcher": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.22.tgz",
+      "integrity": "sha512-z+TvbHW8Q/g2l7/PnfUl0mV9gWxV4d0HT6GQyzkO5QI6QjCvCZGiztnmLX7zoyS16uSMvZ2PoMDfSK9xvZkRRA==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "@greencoast/logger": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@greencoast/logger/-/logger-1.1.0.tgz",
@@ -12879,6 +12979,17 @@
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "intl-messageformat": {
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.11.1.tgz",
+      "integrity": "sha512-kT0i8AIa1Aez8jGn1i9Xva/sdbjOPY15abR82qnU4jnESjxtynHLW1CBh9ehs13sPA8cE/4A2d6LEne91oDp4w==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.11.1",
+        "@formatjs/fast-memoize": "1.2.1",
+        "@formatjs/icu-messageformat-parser": "2.0.16",
+        "tslib": "^2.1.0"
       }
     },
     "is-bigint": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "dayjs": "^1.10.7",
     "discord-api-types": "^0.26.1",
     "humanize-duration": "^3.27.1",
+    "intl-messageformat": "^9.11.1",
     "lodash": "^4.17.21",
     "require-all": "^3.0.0"
   }

--- a/src/classes/ExtendedClient.ts
+++ b/src/classes/ExtendedClient.ts
@@ -6,6 +6,7 @@ import DataProvider from './data/DataProvider';
 import CommandRegistry from './command/CommandRegistry';
 import CommandDispatcher from './command/CommandDispatcher';
 import SlashCommandDeployer from './command/SlashCommandDeployer';
+import Localizer from './locale/Localizer';
 import ClientDefaultHandlers from './events/ClientDefaultHandlers';
 import ExtraClientDefaultHandlers from './events/ExtraClientDefaultHandlers';
 import ExtendedClientOptions from '../interfaces/ExtendedClientOptions';
@@ -84,6 +85,14 @@ export class ExtendedClient extends Discord.Client {
   public deployer: SlashCommandDeployer;
 
   /**
+   * This client's localizer. This value can be `null` if no `localizer` options are
+   * passed to this client's options.
+   * @type {Localizer}
+   * @memberof ExtendedClient
+   */
+  public localizer: Localizer | null;
+
+  /**
    * @param options The client's options. Defaults to an empty object.
    */
   // eslint-disable-next-line max-statements
@@ -107,6 +116,7 @@ export class ExtendedClient extends Discord.Client {
     this.registry = new CommandRegistry(this);
     this.dispatcher = new CommandDispatcher(this, this.registry);
     this.deployer = new SlashCommandDeployer(this);
+    this.localizer = options.localizer ? new Localizer(this, options.localizer) : null;
 
     this.fetchOwner();
     this.registerMessageHandler().registerInteractionHandler();

--- a/src/classes/command/CommandRegistry.ts
+++ b/src/classes/command/CommandRegistry.ts
@@ -192,12 +192,14 @@ class CommandRegistry {
    * | ID of the group | Name of the group        |
    * |-----------------|--------------------------|
    * | `misc`          | `Miscellaneous Commands` |
+   * | `config`        | `Configuration Commands` |
    * @returns This command registry.
    * @emits `client#groupRegistered`
    */
   public registerDefaultGroups(): this {
     this.registerGroups([
-      ['misc', 'Miscellaneous Commands']
+      ['misc', 'Miscellaneous Commands'],
+      ['config', 'Configuration Commands']
     ]);
 
     return this;

--- a/src/classes/command/default/SetLocaleCommand.ts
+++ b/src/classes/command/default/SetLocaleCommand.ts
@@ -25,7 +25,6 @@ class SetLocale extends SlashCommand {
         return input
           .setName('locale')
           .setDescription('The new locale to be used.')
-          .addChoices(client.localizer!.getAvailableLocales().map((l) => [l, l]))
           .setRequired(true);
       }) as SlashCommandBuilder
     });

--- a/src/classes/command/default/SetLocaleCommand.ts
+++ b/src/classes/command/default/SetLocaleCommand.ts
@@ -1,0 +1,55 @@
+import Discord from 'discord.js';
+import { SlashCommandBuilder } from '@discordjs/builders';
+import SlashCommand from '../SlashCommand';
+import ExtendedClient from '../../ExtendedClient';
+
+/**
+ * The default set locale command. This command is part of the `config` group.
+ *
+ * This command updates the locale for the current guild.
+ * @category config - Configuration Commands
+ */
+class SetLocale extends SlashCommand {
+  /**
+   * @param client The client that this command will be used by.
+   */
+  constructor(client: ExtendedClient) {
+    super(client, {
+      name: 'set_locale',
+      emoji: ':earth_americas:',
+      group: 'config',
+      description: 'Update the locale for this guild.',
+      guildOnly: true,
+      userPermissions: [Discord.Permissions.FLAGS.MANAGE_GUILD],
+      dataBuilder: new SlashCommandBuilder().addStringOption((input) => {
+        return input
+          .setName('locale')
+          .setDescription('The new locale to be used.')
+          .addChoices(client.localizer!.getAvailableLocales().map((l) => [l, l]))
+          .setRequired(true);
+      }) as SlashCommandBuilder
+    });
+  }
+
+  /**
+   * Run the set locale command. Usage:
+   * ```text
+   * /set_locale <locale>
+   * ```
+   * @param interaction The [interaction](https://discord.js.org/#/docs/discord.js/stable/class/CommandInteraction) that triggered this command.
+   */
+  public async run(interaction: Discord.CommandInteraction): Promise<void> {
+    const localizer = this.client.localizer!.getLocalizer(interaction.guild!)!; // We know it comes from a guild because of guildOnly.
+    const newLocale = interaction.options.getString('locale')!; // We know it's not null because it is required.
+
+    if (newLocale === localizer.locale) {
+      await interaction.reply(`Locale is already set to ${localizer.locale}.`);
+      return;
+    }
+
+    await localizer.updateLocale(newLocale); // Failure caught by onError.
+    await interaction.reply(`Successfully updated locale to ${newLocale}.`);
+  }
+}
+
+export default SetLocale;

--- a/src/classes/command/default/index.ts
+++ b/src/classes/command/default/index.ts
@@ -5,7 +5,9 @@
  */
 
 import HelpCommand from './HelpCommand';
+import SetLocaleCommand from './SetLocaleCommand';
 
 export {
-  HelpCommand
+  HelpCommand,
+  SetLocaleCommand
 };

--- a/src/classes/locale/GuildLocalizer.ts
+++ b/src/classes/locale/GuildLocalizer.ts
@@ -65,8 +65,7 @@ class GuildLocalizer {
 
     const savedLocale = await this.localizer.client.dataProvider.get(this.guild, this.dataProviderKey, this.locale);
 
-    const availableLocales = this.localizer.getAvailableLocales();
-    if (!availableLocales.includes(savedLocale)) {
+    if (!this.localizer.isLocaleSupported(savedLocale)) {
       throw new Error(`Invalid locale ${savedLocale} received from data provider. Perhaps you changed the value for ${this.dataProviderKey} manually?`);
     }
 
@@ -83,8 +82,7 @@ class GuildLocalizer {
    * @throws Rejects if the given locale is not supported.
    */
   public async updateLocale(locale: string): Promise<void> {
-    const availableLocales = this.localizer.getAvailableLocales();
-    if (!availableLocales.includes(locale)) {
+    if (!this.localizer.isLocaleSupported(locale)) {
       throw new Error(`${locale} is not a supported locale.`);
     }
 

--- a/src/classes/locale/GuildLocalizer.ts
+++ b/src/classes/locale/GuildLocalizer.ts
@@ -1,15 +1,47 @@
-import { Guild } from 'discord.js';
+import Discord from 'discord.js';
 import Localizer from './Localizer';
 
+/**
+ * A class to help with localization of your bot. This handles string translation from the context of the
+ * guild. For more information, check {@link Localizer}.
+ */
 class GuildLocalizer {
+  /**
+   * The main localizer for this guild localizer.
+   * @type {Localizer}
+   * @memberof {GuildLocalizer}
+   */
   public readonly localizer: Localizer;
-  public readonly guild: Guild;
 
+  /**
+   * The guild that corresponds to this guild localizer.
+   * @type {Discord.Guild}
+   * @memberof {GuildLocalizer}
+   */
+  public readonly guild: Discord.Guild;
+
+  /**
+   * The key to be used to save the guild's locale in the client's
+   * data provider.
+   * @type {string}
+   * @default `locale`
+   * @memberof {GuildLocalizer}
+   */
   public readonly dataProviderKey: string;
 
+  /**
+   * The current locale set for the guild. Do not update this value manually, instead use
+   * the `updateLocale()` method.
+   * @type {string}
+   * @memberof {GuildLocalizer}
+   */
   public locale: string;
 
-  constructor(localizer: Localizer, guild: Guild) {
+  /**
+   * @param localizer The main localizer for this guild localizer.
+   * @param guild The guild that corresponds to this guild localizer.
+   */
+  constructor(localizer: Localizer, guild: Discord.Guild) {
     this.localizer = localizer;
     this.guild = guild;
 
@@ -18,6 +50,14 @@ class GuildLocalizer {
     this.locale = localizer.defaultLocale;
   }
 
+  /**
+   * Initializes this guild localizer.
+   * You should call this after initializing the client's data provider since this method
+   * will read the locale set for each guild and will initialize their localizer with that value.
+   * @returns A promise that resolves to the locale set for this guild localizer.
+   * @throws Rejects if a guild localizer was being initialized with an unsupported locale retrieved
+   * from the data provider. This may happen if the locale saved in the data provider was updated manually.
+   */
   public async init(): Promise<string> {
     if (!this.localizer.client.dataProvider) {
       return this.locale;
@@ -35,6 +75,13 @@ class GuildLocalizer {
     return this.locale;
   }
 
+  /**
+   * Updates the locale set to this guild localizer. If the client has a data provider, it will also update
+   * the locale in it for persistence.
+   * @param locale The new locale to be used by this guild localizer.
+   * @returns A promise that resolves once the locale has been updated.
+   * @throws Rejects if the given locale is not supported.
+   */
   public async updateLocale(locale: string): Promise<void> {
     const availableLocales = this.localizer.getAvailableLocales();
     if (!availableLocales.includes(locale)) {
@@ -50,8 +97,18 @@ class GuildLocalizer {
     return this.localizer.client.dataProvider.set(this.guild, this.dataProviderKey, this.locale);
   }
 
-  public t(key: string): string {
-    return this.localizer.translate(key, this.locale);
+  /**
+   * Get the message for the given key translated into the locale of this
+   * guild localizer. You can also supply an object
+   * containing the dynamic values to be used.
+   * @param key The key of the message to translate.
+   * @param values The dynamic values to be replaced in the message.
+   * @returns The translated message.
+   * @throws Throws if the key does not resolve to any message.
+   * @throws Throws if the given locale is not supported.
+   */
+  public t(key: string, values = {}): string {
+    return this.localizer.translate(key, this.locale, values);
   }
 }
 

--- a/src/classes/locale/GuildLocalizer.ts
+++ b/src/classes/locale/GuildLocalizer.ts
@@ -1,0 +1,52 @@
+import { Guild } from 'discord.js';
+import Localizer from './Localizer';
+
+class GuildLocalizer {
+  public readonly localizer: Localizer;
+  public readonly guild: Guild;
+
+  public readonly dataProviderKey: string;
+
+  public locale: string;
+
+  constructor(localizer: Localizer, guild: Guild) {
+    this.localizer = localizer;
+    this.guild = guild;
+
+    this.dataProviderKey = localizer.options.dataProviderKey || 'locale';
+
+    this.locale = localizer.defaultLocale;
+  }
+
+  public async init(): Promise<string> {
+    if (!this.localizer.client.dataProvider) {
+      return this.locale;
+    }
+
+    this.locale = await this.localizer.client.dataProvider.get(this.guild, this.dataProviderKey, this.locale);
+
+    return this.locale;
+  }
+
+  public async updateLocale(locale: string): Promise<void> {
+    const availableLocales = this.localizer.getAvailableLocales();
+
+    if (!availableLocales.includes(locale)) {
+      throw new Error(`${locale} is not a supported locale.`);
+    }
+
+    this.locale = locale;
+
+    if (!this.localizer.client.dataProvider) {
+      return;
+    }
+
+    return this.localizer.client.dataProvider.set(this.guild, this.dataProviderKey, this.locale);
+  }
+
+  public t(key: string): string {
+    return this.localizer.translate(key, this.locale);
+  }
+}
+
+export default GuildLocalizer;

--- a/src/classes/locale/GuildLocalizer.ts
+++ b/src/classes/locale/GuildLocalizer.ts
@@ -107,8 +107,20 @@ class GuildLocalizer {
    * @throws Throws if the key does not resolve to any message.
    * @throws Throws if the given locale is not supported.
    */
-  public t(key: string, values = {}): string {
+  public translate(key: string, values = {}): string {
     return this.localizer.translate(key, this.locale, values);
+  }
+
+  /**
+   * Alias for `translate()`.
+   * @param key The key of the message to translate.
+   * @param values The dynamic values to be replaced in the message.
+   * @returns The translated message.
+   * @throws Throws if the key does not resolve to any message.
+   * @throws Throws if the given locale is not supported.
+   */
+  public t(key: string, values = {}): string {
+    return this.translate(key, values);
   }
 }
 

--- a/src/classes/locale/GuildLocalizer.ts
+++ b/src/classes/locale/GuildLocalizer.ts
@@ -23,14 +23,20 @@ class GuildLocalizer {
       return this.locale;
     }
 
-    this.locale = await this.localizer.client.dataProvider.get(this.guild, this.dataProviderKey, this.locale);
+    const savedLocale = await this.localizer.client.dataProvider.get(this.guild, this.dataProviderKey, this.locale);
+
+    const availableLocales = this.localizer.getAvailableLocales();
+    if (!availableLocales.includes(savedLocale)) {
+      throw new Error(`Invalid locale ${savedLocale} received from data provider. Perhaps you changed the value for ${this.dataProviderKey} manually?`);
+    }
+
+    this.locale = savedLocale;
 
     return this.locale;
   }
 
   public async updateLocale(locale: string): Promise<void> {
     const availableLocales = this.localizer.getAvailableLocales();
-
     if (!availableLocales.includes(locale)) {
       throw new Error(`${locale} is not a supported locale.`);
     }

--- a/src/classes/locale/Localizer.ts
+++ b/src/classes/locale/Localizer.ts
@@ -133,6 +133,19 @@ class Localizer {
   }
 
   /**
+   * Alias for `translate()`.
+   * @param key The key of the message to translate.
+   * @param locale The locale to translate the message to.
+   * @param values The dynamic values to be replaced in the message.
+   * @returns The translated message.
+   * @throws Throws if the key does not resolve to any message.
+   * @throws Throws if the given locale is not supported.
+   */
+  public t(key: string, locale?: string | null, values = {}): string {
+    return this.translate(key, locale, values);
+  }
+
+  /**
    * Get the formatter object to format the message of the given key and locale.
    * @param key The key of the message to translate.
    * @param locale The locale to translate the message to.

--- a/src/classes/locale/Localizer.ts
+++ b/src/classes/locale/Localizer.ts
@@ -4,13 +4,76 @@ import ExtendedClient from '../ExtendedClient';
 import GuildLocalizer from './GuildLocalizer';
 import LocalizerOptions from '../../interfaces/LocalizerOptions';
 
+/**
+ * A class to help with the localization of your bot. This handles string translation based on the
+ * [intl-messageformat](https://formatjs.io/docs/intl-messageformat/) package. Strings are defined in
+ * [ICU](https://formatjs.io/docs/intl-messageformat/#common-usage-example) format and dynamic values inside.
+ * It is recommended to have a data provider set in the client for the locale settings to be saved
+ * persistently for each guild.
+ */
 class Localizer {
+  /**
+   * The client that this localizer will be used by.
+   * @type {ExtendedClient}
+   * @memberof Localizer
+   */
   public readonly client: ExtendedClient;
+
+  /**
+   * An object that maps the name of the locale to another object that contains
+   * all the available messages mapped by their keys. The messages should follow
+   * a ICU standard, for more information on how to structure these messages, please visit the
+   * [following link](https://formatjs.io/docs/intl-messageformat/#common-usage-example).
+   *
+   * The following is an example of how to structure this object:
+   *
+   * en: {
+   *   'message.test.hello': 'Hello',
+   *   'message.test.bye': 'Bye',
+   *   'message.test.with_value': 'Hello {name}!'
+   * },
+   * es: {
+   *   'message.test.hello': 'Hola',
+   *   'message.test.bye': 'Adios',
+   *   'message.test.with_value': 'Hola {name}!'
+   * },
+   * fr: {
+   *   'message.test.hello': 'Bonjour',
+   *   'message.test.bye': 'Au revoir',
+   *   'message.test.with_value': 'Bonjour {name}!'
+   * }
+   * @type {Record<string, Record<string, string>>}
+   * @memberof {Localizer}
+   */
   public readonly localeStrings: Record<string, Record<string, string>>;
+
+  /**
+   * The default locale to be used in case a guild does not have its locale set in the
+   * client's data provider. You should set a data provider before setting this up so
+   * the guild's locale can be saved persistently.
+   * @type {string}
+   * @memberof {Localizer}
+   */
   public readonly defaultLocale: string;
+
+  /**
+   * The options for this localizer.
+   * @type {LocalizerOptions}
+   * @memberof {Localizer}
+   */
   public readonly options: LocalizerOptions;
+
+  /**
+   * The {@link GuildLocalizer}s for each guild.
+   * @type {Discord.Collection<Discord.Snowflake, GuildLocalizer>}
+   * @memberof {Localizer}
+   */
   public readonly guildLocalizers: Discord.Collection<Discord.Snowflake, GuildLocalizer>;
 
+  /**
+   * @param client The client that this localizer will be used by.
+   * @param options The options for this localizer.
+   */
   constructor(client: ExtendedClient, options: LocalizerOptions) {
     this.client = client;
     this.localeStrings = options.localeStrings;
@@ -19,6 +82,16 @@ class Localizer {
     this.guildLocalizers = new Discord.Collection();
   }
 
+  /**
+   * Initializes all the {@link GuildLocalizer}s for each guild the client is connected to.
+   * You should call this after initializing the client's data provider since this method
+   * will read the locale set for each guild and will initialize their localizer with that value.
+   * In case the client does not have a data provider, you should still call this method, but the
+   * localizers will be initialized with the default locale.
+   * @returns A promise that resolves once all guild localizers are ready.
+   * @throws Rejects if a guild localizer was being initialized with an unsupported locale retrieved
+   * from the data provider. This may happen if the locale saved in the data provider was updated manually.
+   */
   public init(): Promise<string[]> {
     return Promise.all(this.client.guilds.cache.map((guild) => {
       const localizer = new GuildLocalizer(this, guild);
@@ -28,18 +101,45 @@ class Localizer {
     }));
   }
 
+  /**
+   * Get the localizer for the given guild.
+   * @param guild
+   * @returns The guild localizer for the given guild.
+   */
   public getLocalizer(guild: Discord.Guild): GuildLocalizer | undefined {
     return this.guildLocalizers.get(guild.id);
   }
 
+  /**
+   * Get a list of all the available locales retrieved based on the keys of `localeStrings`.
+   * @returns An array containing all the available locales.
+   */
   public getAvailableLocales(): string[] {
     return Object.keys(this.localeStrings);
   }
 
+  /**
+   * Get the message for the given key translated into the given locale. You can also supply an object
+   * containing the dynamic values to be used.
+   * @param key The key of the message to translate.
+   * @param locale The locale to translate the message to.
+   * @param values The dynamic values to be replaced in the message.
+   * @returns The translated message.
+   * @throws Throws if the key does not resolve to any message.
+   * @throws Throws if the given locale is not supported.
+   */
   public translate(key: string, locale?: string | null, values = {}): string {
     return this.getMessage(key, locale || this.defaultLocale).format(values) as string;
   }
 
+  /**
+   * Get the formatter object to format the message of the given key and locale.
+   * @param key The key of the message to translate.
+   * @param locale The locale to translate the message to.
+   * @returns The formatter object for translating the message.
+   * @throws Throws if the key does not resolve to any message.
+   * @throws Throws if the given locale is not supported.
+   */
   private getMessage(key: string, locale: string): IntlMessageFormat {
     const messagesForLocale = this.localeStrings[locale];
 

--- a/src/classes/locale/Localizer.ts
+++ b/src/classes/locale/Localizer.ts
@@ -1,0 +1,41 @@
+import IntlMessageFormat from 'intl-messageformat';
+import ExtendedClient from '../ExtendedClient';
+import LocalizerOptions from '../../interfaces/LocalizerOptions';
+
+class Localizer {
+  public readonly client: ExtendedClient;
+  public readonly localeStrings: Record<string, Record<string, string>>;
+  public readonly defaultLocale: string;
+
+  constructor(client: ExtendedClient, options: LocalizerOptions) {
+    this.client = client;
+    this.localeStrings = options.localeStrings;
+    this.defaultLocale = options.defaultLocale;
+  }
+
+  public getAvailableLocales(): string[] {
+    return Object.keys(this.localeStrings);
+  }
+
+  public translate(key: string, locale?: string | null, values = {}): string {
+    return this.getMessage(key, locale || this.defaultLocale).format(values) as string;
+  }
+
+  private getMessage(key: string, locale: string): IntlMessageFormat {
+    const messagesForLocale = this.localeStrings[locale];
+
+    if (!messagesForLocale) {
+      throw new Error(`No messages with locale ${locale} exist!`);
+    }
+
+    const message = messagesForLocale[key];
+
+    if (!message) {
+      throw new Error(`No message with key ${key} for locale ${locale} exists!`);
+    }
+
+    return new IntlMessageFormat(this.localeStrings[locale][key]);
+  }
+}
+
+export default Localizer;

--- a/src/classes/locale/Localizer.ts
+++ b/src/classes/locale/Localizer.ts
@@ -73,10 +73,16 @@ class Localizer {
   /**
    * @param client The client that this localizer will be used by.
    * @param options The options for this localizer.
+   * @throws Throws if the supplied default locale is not supported.
    */
   constructor(client: ExtendedClient, options: LocalizerOptions) {
     this.client = client;
     this.localeStrings = options.localeStrings;
+
+    if (!this.getAvailableLocales().includes(options.defaultLocale)) {
+      throw new Error(`${options.defaultLocale} is not a supported locale.`);
+    }
+
     this.defaultLocale = options.defaultLocale;
     this.options = options;
     this.guildLocalizers = new Discord.Collection();

--- a/src/classes/locale/Localizer.ts
+++ b/src/classes/locale/Localizer.ts
@@ -6,11 +6,13 @@ class Localizer {
   public readonly client: ExtendedClient;
   public readonly localeStrings: Record<string, Record<string, string>>;
   public readonly defaultLocale: string;
+  public readonly options: LocalizerOptions;
 
   constructor(client: ExtendedClient, options: LocalizerOptions) {
     this.client = client;
     this.localeStrings = options.localeStrings;
     this.defaultLocale = options.defaultLocale;
+    this.options = options;
   }
 
   public getAvailableLocales(): string[] {

--- a/src/classes/locale/Localizer.ts
+++ b/src/classes/locale/Localizer.ts
@@ -79,7 +79,7 @@ class Localizer {
     this.client = client;
     this.localeStrings = options.localeStrings;
 
-    if (!this.getAvailableLocales().includes(options.defaultLocale)) {
+    if (!this.isLocaleSupported(options.defaultLocale)) {
       throw new Error(`${options.defaultLocale} is not a supported locale.`);
     }
 
@@ -122,6 +122,15 @@ class Localizer {
    */
   public getAvailableLocales(): string[] {
     return Object.keys(this.localeStrings);
+  }
+
+  /**
+   * Check whether the given locale is supported.
+   * @param locale The locale to test.
+   * @returns `true` if the locale is supported.
+   */
+  public isLocaleSupported(locale: string): boolean {
+    return this.getAvailableLocales().includes(locale);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import CommandGroup from './classes/command/CommandGroup';
 import CommandRegistry from './classes/command/CommandRegistry';
 import CommandDispatcher from './classes/command/CommandDispatcher';
 import SlashCommandDeployer from './classes/command/SlashCommandDeployer';
+import Localizer from './classes/locale/Localizer';
 
 import * as DefaultCommands from './classes/command/default';
 
@@ -30,6 +31,7 @@ import PresenceData from './interfaces/PresenceData';
 import ConfigProviderOptions from './interfaces/ConfigProviderOptions';
 import CommandInfo from './interfaces/CommandInfo';
 import SlashCommandInfo from './interfaces/SlashCommandInfo';
+import LocalizerOptions from './interfaces/LocalizerOptions';
 
 import { ConfigValue, ConfigCustomValidators, CommandTrigger, PresenceTemplaterGetters } from './types';
 
@@ -52,6 +54,7 @@ export {
   CommandRegistry,
   CommandDispatcher,
   SlashCommandDeployer,
+  Localizer,
   DefaultCommands,
   ExtendedClientOptions,
   ExtendedClientEvents,
@@ -60,6 +63,7 @@ export {
   ConfigProviderOptions,
   CommandInfo,
   SlashCommandInfo,
+  LocalizerOptions,
   ConfigValue,
   ConfigCustomValidators,
   CommandTrigger,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import CommandRegistry from './classes/command/CommandRegistry';
 import CommandDispatcher from './classes/command/CommandDispatcher';
 import SlashCommandDeployer from './classes/command/SlashCommandDeployer';
 import Localizer from './classes/locale/Localizer';
+import GuildLocalizer from './classes/locale/GuildLocalizer';
 
 import * as DefaultCommands from './classes/command/default';
 
@@ -55,6 +56,7 @@ export {
   CommandDispatcher,
   SlashCommandDeployer,
   Localizer,
+  GuildLocalizer,
   DefaultCommands,
   ExtendedClientOptions,
   ExtendedClientEvents,

--- a/src/interfaces/ExtendedClientOptions.ts
+++ b/src/interfaces/ExtendedClientOptions.ts
@@ -1,6 +1,7 @@
 import Discord from 'discord.js';
 import ConfigProvider from '../classes/config/ConfigProvider';
 import PresenceManagerOptions from './PresenceManagerOptions';
+import LocalizerOptions from './LocalizerOptions';
 
 /**
  * The options used to create a {@link ExtendedClient}.
@@ -47,7 +48,12 @@ interface ExtendedClientOptions extends Discord.ClientOptions {
    * it is recommended to specify one. This is used to automatically deploy
    * slash commands to the testing guild.
    */
-  testingGuildID?: string
+  testingGuildID?: string,
+
+  /**
+   * The client's localizer's options.
+   */
+  localizer?: LocalizerOptions
 }
 
 export default ExtendedClientOptions;

--- a/src/interfaces/LocalizerOptions.ts
+++ b/src/interfaces/LocalizerOptions.ts
@@ -1,0 +1,6 @@
+interface LocalizerOptions {
+  localeStrings: Record<string, Record<string, string>>,
+  defaultLocale: string
+}
+
+export default LocalizerOptions;

--- a/src/interfaces/LocalizerOptions.ts
+++ b/src/interfaces/LocalizerOptions.ts
@@ -1,6 +1,7 @@
 interface LocalizerOptions {
   localeStrings: Record<string, Record<string, string>>,
-  defaultLocale: string
+  defaultLocale: string,
+  dataProviderKey?: string
 }
 
 export default LocalizerOptions;

--- a/src/interfaces/LocalizerOptions.ts
+++ b/src/interfaces/LocalizerOptions.ts
@@ -1,6 +1,45 @@
+/**
+ * The options used to create a {@link Localizer}.
+ */
 interface LocalizerOptions {
+  /**
+   * An object that maps the name of the locale to another object that contains
+   * all the available messages mapped by their keys. The messages should follow
+   * a ICU standard, for more information on how to structure these messages, please visit the
+   * [following link](https://formatjs.io/docs/intl-messageformat/#common-usage-example).
+   *
+   * The following is an example of how to structure this object:
+   *
+   * en: {
+   *   'message.test.hello': 'Hello',
+   *   'message.test.bye': 'Bye',
+   *   'message.test.with_value': 'Hello {name}!'
+   * },
+   * es: {
+   *   'message.test.hello': 'Hola',
+   *   'message.test.bye': 'Adios',
+   *   'message.test.with_value': 'Hola {name}!'
+   * },
+   * fr: {
+   *   'message.test.hello': 'Bonjour',
+   *   'message.test.bye': 'Au revoir',
+   *   'message.test.with_value': 'Bonjour {name}!'
+   * }
+   */
   localeStrings: Record<string, Record<string, string>>,
+
+  /**
+   * The default locale to be used in case a guild does not have its locale set in the
+   * client's data provider. You should set a data provider before setting this up so
+   * the guild's locale can be saved persistently.
+   */
   defaultLocale: string,
+
+  /**
+   * The key used to save the value of the locale set per guild in the client's data provider
+   * (if any).
+   * @defaultValue `locale`
+   */
   dataProviderKey?: string
 }
 

--- a/test/classes/command/CommandRegistry.spec.ts
+++ b/test/classes/command/CommandRegistry.spec.ts
@@ -177,6 +177,7 @@ describe('Classes: Command: CommandRegistry', () => {
         registry.registerDefaultGroups();
 
         expect(registry.groups.get('misc')!.name).toBe('Miscellaneous Commands');
+        expect(registry.groups.get('config')!.name).toBe('Configuration Commands');
       });
     });
 
@@ -186,6 +187,7 @@ describe('Classes: Command: CommandRegistry', () => {
         registry.registerDefaultCommands();
 
         expect(registry.commands.get('help')).toBeInstanceOf(DefaultCommands.HelpCommand);
+        expect(registry.commands.get('set_locale')).toBeInstanceOf(DefaultCommands.SetLocaleCommand);
       });
 
       it('should throw if the default groups are not registered prior.', () => {

--- a/test/classes/command/default/SetLocaleCommand.spec.ts
+++ b/test/classes/command/default/SetLocaleCommand.spec.ts
@@ -1,0 +1,76 @@
+import Discord from 'discord.js';
+import SetLocaleCommand from '../../../../src/classes/command/default/SetLocaleCommand';
+import ExtendedClient from '../../../../src/classes/ExtendedClient';
+import GuildLocalizer from '../../../../src/classes/locale/GuildLocalizer';
+import { InteractionMock, GuildMock } from '../../../../__mocks__/discordMocks';
+import { mockedLocaleStrings } from '../../../../__mocks__/locale';
+
+describe('Classes: Command: Default: SetLocaleCommand', () => {
+  let command: SetLocaleCommand;
+
+  let clientMock: ExtendedClient;
+  let interactionMock: Discord.CommandInteraction;
+  let guildMock: Discord.Guild;
+  let guildLocalizerMock: GuildLocalizer;
+
+  beforeEach(() => {
+    clientMock = new ExtendedClient({ intents: [], localizer: { defaultLocale: 'en', localeStrings: mockedLocaleStrings } });
+    interactionMock = new InteractionMock() as unknown as Discord.CommandInteraction;
+
+    guildMock = new GuildMock() as Discord.Guild;
+    guildLocalizerMock = new GuildLocalizer(clientMock.localizer!, guildMock);
+
+    command = new SetLocaleCommand(clientMock);
+  });
+
+  describe('run()', () => {
+    it('should update the locale for that guild.', () => {
+      const getStringSpy = interactionMock.options.getString as jest.Mock;
+      getStringSpy.mockReturnValue('fr');
+      jest.spyOn(clientMock.localizer!, 'getLocalizer').mockReturnValue(guildLocalizerMock);
+
+      expect(guildLocalizerMock.locale).toBe('en');
+      return command.run(interactionMock)
+        .then(() => {
+          expect(guildLocalizerMock.locale).toBe('fr');
+        });
+    });
+
+    it('should not update the locale if the same one is already set.', () => {
+      const getStringSpy = interactionMock.options.getString as jest.Mock;
+      getStringSpy.mockReturnValue('en');
+      jest.spyOn(clientMock.localizer!, 'getLocalizer').mockReturnValue(guildLocalizerMock);
+
+      expect(guildLocalizerMock.locale).toBe('en');
+      return command.run(interactionMock)
+        .then(() => {
+          const updateSpy = jest.spyOn(guildLocalizerMock, 'updateLocale');
+          expect(updateSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    it('should reply if the new locale is the same as previous.', () => {
+      const getStringSpy = interactionMock.options.getString as jest.Mock;
+      getStringSpy.mockReturnValue('en');
+      jest.spyOn(clientMock.localizer!, 'getLocalizer').mockReturnValue(guildLocalizerMock);
+
+      return command.run(interactionMock)
+        .then(() => {
+          const replySpy = interactionMock.reply as jest.Mock;
+          expect(replySpy.mock.calls[0][0]).toContain('already set');
+        });
+    });
+
+    it('should reply that the locale has been updated.', () => {
+      const getStringSpy = interactionMock.options.getString as jest.Mock;
+      getStringSpy.mockReturnValue('fr');
+      jest.spyOn(clientMock.localizer!, 'getLocalizer').mockReturnValue(guildLocalizerMock);
+
+      return command.run(interactionMock)
+        .then(() => {
+          const replySpy = interactionMock.reply as jest.Mock;
+          expect(replySpy.mock.calls[0][0]).toContain('fr');
+        });
+    });
+  });
+});

--- a/test/classes/locale/GuildLocalizer.spec.ts
+++ b/test/classes/locale/GuildLocalizer.spec.ts
@@ -102,11 +102,19 @@ describe('Classes: Locale: GuildLocalizer', () => {
     });
   });
 
-  describe('t()', () => {
+  describe('translate()', () => {
     it('should call localizer.translate with the correct values.', () => {
       const translateSpy = jest.spyOn(localizer.localizer, 'translate');
+      localizer.translate('message.test.hello');
+      expect(translateSpy).toHaveBeenCalledWith('message.test.hello', localizer.locale, {});
+    });
+  });
+
+  describe('t()', () => {
+    it('should call translate with the correct values.', () => {
+      const translateSpy = jest.spyOn(localizer, 'translate');
       localizer.t('message.test.hello');
-      expect(translateSpy).toHaveBeenCalledWith('message.test.hello', localizer.locale);
+      expect(translateSpy).toHaveBeenCalledWith('message.test.hello', {});
     });
   });
 });

--- a/test/classes/locale/GuildLocalizer.spec.ts
+++ b/test/classes/locale/GuildLocalizer.spec.ts
@@ -1,0 +1,101 @@
+import Discord from 'discord.js';
+import GuildLocalizer from '../../../src/classes/locale/GuildLocalizer';
+import Localizer from '../../../src/classes/locale/Localizer';
+import ExtendedClient from '../../../src/classes/ExtendedClient';
+import { GuildMock } from '../../../__mocks__/discordMocks';
+import ConcreteDataProvider from '../../../__mocks__/dataProvider';
+import { mockedLocaleStrings } from '../../../__mocks__/locale';
+
+const clientMock = new ExtendedClient();
+const mainLocalizerMock = new Localizer(clientMock, { defaultLocale: 'en', localeStrings: mockedLocaleStrings });
+const guildMock = new GuildMock() as Discord.Guild;
+
+describe('Classes: Locale: GuildLocalizer', () => {
+  let localizer: GuildLocalizer;
+
+  let getSpy: jest.SpyInstance;
+  let setSpy: jest.SpyInstance;
+
+  beforeAll(async() => {
+    await clientMock.setDataProvider(new ConcreteDataProvider(clientMock));
+    getSpy = jest.spyOn(clientMock.dataProvider!, 'get');
+    setSpy = jest.spyOn(clientMock.dataProvider!, 'set');
+  });
+
+  beforeEach(() => {
+    localizer = new GuildLocalizer(mainLocalizerMock, guildMock);
+  });
+
+  describe('init()', () => {
+    it('should resolve the default locale if no data provider is present in client.', () => {
+      const client = new ExtendedClient();
+      const mainLocalizer = new Localizer(client, { defaultLocale: 'en', localeStrings: mockedLocaleStrings });
+      const guildLocalizer = new GuildLocalizer(mainLocalizer, guildMock);
+
+      return guildLocalizer.init()
+        .then((locale) => {
+          expect(locale).toBe('en');
+        });
+    });
+
+    it('should resolve the locale stored in the data provider.', () => {
+      getSpy.mockResolvedValueOnce('fr');
+
+      return localizer.init()
+        .then((locale) => {
+          expect(locale).toBe('fr');
+        });
+    });
+
+    it('should set the locale value.', () => {
+      getSpy.mockResolvedValueOnce('fr');
+
+      return localizer.init()
+        .then(() => {
+          expect(localizer.locale).toBe('fr');
+        });
+    });
+  });
+
+  describe('updateLocale()', () => {
+    it('should reject if the supplied locale is not supported.', () => {
+      expect.assertions(1);
+
+      return localizer.updateLocale('unknown')
+        .catch((error) => {
+          expect(error.message).toContain('not a supported locale');
+        });
+    });
+
+    it('should not update the locale if the supplied one is not supported.', () => {
+      expect.assertions(1);
+
+      return localizer.updateLocale('unknown')
+        .catch(() => {
+          expect(localizer.locale).toBe('en');
+        });
+    });
+
+    it('should set the locale value with the one supplied.', () => {
+      return localizer.updateLocale('es')
+        .then(() => {
+          expect(localizer.locale).toBe('es');
+        });
+    });
+
+    it('should update the locale in the data provider.', () => {
+      return localizer.updateLocale('es')
+        .then(() => {
+          expect(setSpy).toHaveBeenCalledWith(localizer.guild, 'locale', 'es');
+        });
+    });
+  });
+
+  describe('t()', () => {
+    it('should call localizer.translate with the correct values.', () => {
+      const translateSpy = jest.spyOn(localizer.localizer, 'translate');
+      localizer.t('message.test.hello');
+      expect(translateSpy).toHaveBeenCalledWith('message.test.hello', localizer.locale);
+    });
+  });
+});

--- a/test/classes/locale/GuildLocalizer.spec.ts
+++ b/test/classes/locale/GuildLocalizer.spec.ts
@@ -38,6 +38,17 @@ describe('Classes: Locale: GuildLocalizer', () => {
         });
     });
 
+    it('should reject if the locale stored is not supported.', () => {
+      getSpy.mockResolvedValueOnce('unknown');
+      expect.assertions(2);
+
+      return localizer.init()
+        .catch((error) => {
+          expect(error).toBeInstanceOf(Error);
+          expect(localizer.locale).toBe('en');
+        });
+    });
+
     it('should resolve the locale stored in the data provider.', () => {
       getSpy.mockResolvedValueOnce('fr');
 

--- a/test/classes/locale/Localizer.spec.ts
+++ b/test/classes/locale/Localizer.spec.ts
@@ -17,6 +17,14 @@ describe('Classes: Locale: Localizer', () => {
     localizer = new Localizer(clientMock, { defaultLocale: 'en', localeStrings: mockedLocaleStrings });
   });
 
+  describe('constructor()', () => {
+    it('should throw if the default locale is not supported.', () => {
+      expect(() => {
+        localizer = new Localizer(clientMock, { defaultLocale: 'unknown', localeStrings: mockedLocaleStrings });
+      }).toThrow();
+    });
+  });
+
   describe('init()', () => {
     it('should populate guildLocalizers with their respective localizers.', () => {
       return localizer.init()

--- a/test/classes/locale/Localizer.spec.ts
+++ b/test/classes/locale/Localizer.spec.ts
@@ -1,14 +1,46 @@
+import Discord from 'discord.js';
 import Localizer from '../../../src/classes/locale/Localizer';
+import GuildLocalizer from '../../../src/classes/locale/GuildLocalizer';
 import ExtendedClient from '../../../src/classes/ExtendedClient';
 import { mockedLocaleStrings } from '../../../__mocks__/locale';
+import { GuildMock } from '../../../__mocks__/discordMocks';
+
+jest.mock('discord.js');
 
 const clientMock = new ExtendedClient();
+const guildMock = new GuildMock() as Discord.Guild;
 
 describe('Classes: Locale: Localizer', () => {
   let localizer: Localizer;
 
   beforeEach(() => {
     localizer = new Localizer(clientMock, { defaultLocale: 'en', localeStrings: mockedLocaleStrings });
+  });
+
+  describe('init()', () => {
+    it('should populate guildLocalizers with their respective localizers.', () => {
+      return localizer.init()
+        .then(() => {
+          expect(localizer.guildLocalizers.size).toBe(3);
+          expect(localizer.guildLocalizers.each((l) => l instanceof GuildLocalizer));
+        });
+    });
+
+    it('should resolve the locales of each guild localizer.', () => {
+      return localizer.init()
+        .then((locales) => {
+          expect(locales).toStrictEqual(['en', 'en', 'en']);
+        });
+    });
+  });
+
+  describe('getLocalizer()', () => {
+    it("should return the specified guild's localizer.", () => {
+      const guildLocalizer = new GuildLocalizer(localizer, guildMock);
+      localizer.guildLocalizers.set(guildMock.id, guildLocalizer);
+
+      expect(localizer.getLocalizer(guildMock)).toBe(guildLocalizer);
+    });
   });
 
   describe('getAvailableLocales()', () => {

--- a/test/classes/locale/Localizer.spec.ts
+++ b/test/classes/locale/Localizer.spec.ts
@@ -94,4 +94,12 @@ describe('Classes: Locale: Localizer', () => {
       expect(french).toBe('Bonjour moonstar!');
     });
   });
+
+  describe('t()', () => {
+    it('should call translate with the correct values.', () => {
+      const translateSpy = jest.spyOn(localizer, 'translate');
+      localizer.t('message.test.hello', 'en');
+      expect(translateSpy).toHaveBeenCalledWith('message.test.hello', 'en', {});
+    });
+  });
 });

--- a/test/classes/locale/Localizer.spec.ts
+++ b/test/classes/locale/Localizer.spec.ts
@@ -1,25 +1,8 @@
 import Localizer from '../../../src/classes/locale/Localizer';
 import ExtendedClient from '../../../src/classes/ExtendedClient';
+import { mockedLocaleStrings } from '../../../__mocks__/locale';
 
 const clientMock = new ExtendedClient();
-
-const mockedLocaleStrings = {
-  en: {
-    'message.test.hello': 'Hello',
-    'message.test.bye': 'Bye',
-    'message.test.with_value': 'Hello {name}!'
-  },
-  es: {
-    'message.test.hello': 'Hola',
-    'message.test.bye': 'Adios',
-    'message.test.with_value': 'Hola {name}!'
-  },
-  fr: {
-    'message.test.hello': 'Bonjour',
-    'message.test.bye': 'Au revoir',
-    'message.test.with_value': 'Bonjour {name}!'
-  }
-};
 
 describe('Classes: Locale: Localizer', () => {
   let localizer: Localizer;

--- a/test/classes/locale/Localizer.spec.ts
+++ b/test/classes/locale/Localizer.spec.ts
@@ -1,0 +1,82 @@
+import Localizer from '../../../src/classes/locale/Localizer';
+import ExtendedClient from '../../../src/classes/ExtendedClient';
+
+const clientMock = new ExtendedClient();
+
+const mockedLocaleStrings = {
+  en: {
+    'message.test.hello': 'Hello',
+    'message.test.bye': 'Bye',
+    'message.test.with_value': 'Hello {name}!'
+  },
+  es: {
+    'message.test.hello': 'Hola',
+    'message.test.bye': 'Adios',
+    'message.test.with_value': 'Hola {name}!'
+  },
+  fr: {
+    'message.test.hello': 'Bonjour',
+    'message.test.bye': 'Au revoir',
+    'message.test.with_value': 'Bonjour {name}!'
+  }
+};
+
+describe('Classes: Locale: Localizer', () => {
+  let localizer: Localizer;
+
+  beforeEach(() => {
+    localizer = new Localizer(clientMock, { defaultLocale: 'en', localeStrings: mockedLocaleStrings });
+  });
+
+  describe('getAvailableLocales()', () => {
+    it('should return the available locales.', () => {
+      const locales = localizer.getAvailableLocales();
+      expect(locales).toContain('en');
+      expect(locales).toContain('es');
+      expect(locales).toContain('fr');
+    });
+  });
+
+  describe('translate()', () => {
+    it('should throw if given an invalid locale.', () => {
+      expect(() => {
+        localizer.translate('message.test.hello', 'unknown');
+      }).toThrow();
+    });
+
+    it('should throw if given an invalid message key.', () => {
+      expect(() => {
+        localizer.translate('unknown', 'en');
+      }).toThrow();
+    });
+
+    it('should return the message string translated.', () => {
+      const english = localizer.translate('message.test.hello', 'en');
+      const spanish = localizer.translate('message.test.hello', 'es');
+      const french = localizer.translate('message.test.hello', 'fr');
+
+      expect(english).toBe('Hello');
+      expect(spanish).toBe('Hola');
+      expect(french).toBe('Bonjour');
+    });
+
+    it('should use the default locale if no locale is given.', () => {
+      const translated1 = localizer.translate('message.test.bye');
+      const translated2 = localizer.translate('message.test.bye', null);
+
+      expect(translated1).toBe('Bye');
+      expect(translated2).toBe('Bye');
+    });
+
+    it('should return the message string translated with values applied.', () => {
+      const name = 'moonstar';
+      const english = localizer.translate('message.test.with_value', 'en', { name });
+      const spanish = localizer.translate('message.test.with_value', 'es', { name });
+      const french = localizer.translate('message.test.with_value', 'fr', { name });
+
+      expect(english).toBe('Hello moonstar!');
+      expect(spanish).toBe('Hola moonstar!');
+      expect(french).toBe('Bonjour moonstar!');
+    });
+  });
+});

--- a/test/classes/locale/Localizer.spec.ts
+++ b/test/classes/locale/Localizer.spec.ts
@@ -60,6 +60,16 @@ describe('Classes: Locale: Localizer', () => {
     });
   });
 
+  describe('isLocaleSupported()', () => {
+    it('should return true if the locale is supported.', () => {
+      expect(localizer.isLocaleSupported('en')).toBe(true);
+    });
+
+    it('should return false if the locale is not supported.', () => {
+      expect(localizer.isLocaleSupported('unknown')).toBe(false);
+    });
+  });
+
   describe('translate()', () => {
     it('should throw if given an invalid locale.', () => {
       expect(() => {


### PR DESCRIPTION
### :pencil: Checklist

Make sure that your PR fulfills these requirements:

- [x] Tests have been added for this feature.
- [x] Code is properly documented.
- [x] All tests pass on your local machine.
- [x] Code has been linted with the proper rules.
- [x] I have added the correct assignees for code review.

### :page_facing_up: Description

This PR adds support for localizing the bot. You can specify the translated strings by specifying a `localizer` object in the client's options. The localizer will know what locale to use depending on the guild. The guild's locale is saved in the data provider (if any is available) to keep it persistent across restarts. This also adds a default SetLocaleCommand class which can be used by registering the defaults in `client.registry`.

### :pushpin: Does this PR address any issue?

#34
