### PR TITLE
Version 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ const config = new ConfigProvider({
     TOKEN: ['string', 'null'], // With a 'null' type, you can pass 'null' to have it as null.
     MY_ID: 'number',
     OPTIONAL_FLAG: ['boolean', 'null'],
-    MY_ENUM: 'string'
+    MY_ENUM: 'string',
+    MY_NUM_ARRAY: 'number[]' // You can pass arrays through JSON or comma-separated values through env variables.
   },
   customValidators: { // These are the custom validators to use instead of the basic type based validator.
     MY_ENUM: (value) => {

--- a/README.md
+++ b/README.md
@@ -172,6 +172,83 @@ client.on('ready', () => {
 });
 ```
 
+### Localizing Your Bot
+
+The package contains a [Localizer](https://docs.greencoaststudios.com/discord.js-extended/master/classes/discord_js_extended.localizer.html) class to help with the localization of your bot. In order to use it, you should pass a `localizer` object to your `client` constructor and
+initialize the localizer in the `ready` event.
+
+```js
+const client = new ExtendedClient({
+  localizer: {
+    defaultLocale: 'en', // The default locale for your bot.
+    dataProviderKey: 'locale', // The key to be used to store the locale for each guild in the client's data provider.
+    localeStrings: locales
+  }
+});
+
+client.on('ready', async() => {
+  await client.setDataProvider(new DataProvider()); // Should set the data provider before.
+  await client.localizer.init(); // Initializes the localizer.  
+});
+```
+
+The `localeStrings` object should map the name of the locale to another object that maps the message keys with their corresponding message string in its respective language.
+In the example above, the variable `locales` could be:
+
+```js
+const locales = {
+  en: {
+    'message.test.hello': 'Hello',
+    'message.test.bye': 'Bye',
+    'message.test.with_value': 'Hello {name}!'
+  },
+  es: {
+    'message.test.hello': 'Hola',
+    'message.test.bye': 'Adios',
+    'message.test.with_value': 'Hola {name}!'
+  },
+  fr: {
+    'message.test.hello': 'Bonjour',
+    'message.test.bye': 'Au revoir',
+    'message.test.with_value': 'Bonjour {name}!'
+  }
+};
+```
+
+Locale messages should follow the [ICU format](https://formatjs.io/docs/intl-messageformat/#common-usage-example).
+
+Inside a command, you may use the localizer in the following manner:
+
+```js
+class MyCommand extends SlashCommand {
+  async run(interaction) {
+    const localizer = this.client.localizer.getLocalizer(interaction.guild);
+    
+    interaction.reply(localizer.t('message.test.hello'));
+    interaction.reply(localizer.t('message.test.with_value', { name: 'your name' }));
+  }
+}
+```
+
+This uses the locale saved for the guild. You can change the locale for the guild as such:
+
+```js
+class MyCommand extends SlashCommand {
+  async run(interaction) {
+    const localizer = this.client.localizer.getLocalizer(interaction.guild);
+    
+    await localizer.updateLocale('fr');
+    interaction.reply(`Updated locale to ${localizer.locale}`);
+  }
+}
+```
+
+If you're outside the context of a guild, you can still use the localizer by using:
+
+```js
+client.localizer.t('message.test.with_value', 'es', { name: 'your name' });
+```
+
 ### Creating Commands
 
 The package contains a [RegularCommand](https://docs.greencoaststudios.com/discord.js-extended/master/classes/discord_js_extended.regularcommand.html) to facilitate the creation of commands. In order to create one, you need to create a class that extends RegularCommand and implements a `run()` method.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ npm install discord.js @greencoast/discord.js-extended
 
 This package covers client configuration from environment variables and/or JSON files through the [ConfigProvider](https://docs.greencoaststudios.com/discord.js-extended/master/classes/discord_js_extended.configprovider.html) class, which makes it easy to add configuration to a bot. Consider checking the [documentation page](https://docs.greencoaststudios.com/discord.js-extended/master/classes/discord_js_extended.configprovider.html) to see how to use this.
 
+You may also specify custom validators for even more control of how config is provided to your bot. Simply, pass a `customValidators` property to the `ConfigProvider` options, and map the key of the config to its validator function. Your validator function should
+throw a `TypeError` if the given value is invalid based on your criteria.
+
 An example of a bot's configuration may be as follows:
 
 ```js
@@ -47,13 +50,23 @@ const config = new ConfigProvider({
     PREFIX: '!', // Adds a default value for the PREFIX config.
     TOKEN: null, // Adds a default value for the TOKEN config.
     MY_ID: 123,
-    OPTIONAL_FLAG: false
+    OPTIONAL_FLAG: false,
+    MY_ENUM: 'enum1'
   },
   types: { // These are the types of the configuration. The provider validates that the config receives the proper configuration types.
     PREFIX: 'string',
     TOKEN: ['string', 'null'], // With a 'null' type, you can pass 'null' to have it as null.
     MY_ID: 'number',
-    OPTIONAL_FLAG: ['boolean', 'null']
+    OPTIONAL_FLAG: ['boolean', 'null'],
+    MY_ENUM: 'string'
+  },
+  customValidators: { // These are the custom validators to use instead of the basic type based validator.
+    MY_ENUM: (value) => {
+      const validValues = ['enum1', 'enum2', 'enum3'];
+      if (!validValues.includes(value)) {
+        throw new TypeError(`${value} is not a valid value for MY_ENUM, you should use: ${validValues.join(', ')}`);
+      }
+    }
   }
 });
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,11 @@ const client = new ExtendedClient({
   owner: '123', // The ID of the bot's owner.
   prefix: '!', // The bot's prefix to be used.
   presence: {
-    templates: ['presence 1', 'presence 2'], // The presence statuses used by this bot.
-    refreshInterval: 3600000 // Update the bot's presence every hour.
+    templates: ['presence 1', 'presence 2', '{custom_key} hi!'], // The presence statuses used by this bot.
+    refreshInterval: 3600000, // Update the bot's presence every hour.
+    customGetters: {
+      custom_key: async() => Math.random().toString() // Define custom getters for keys to replace on the presence strings.
+    }
   },
   errorOwnerReporting: true, // Sends DMs to the bot's owner whenever a command throws an error.
   intents: [Intents.FLAGS.GUILDS]
@@ -98,7 +101,8 @@ const client = new ExtendedClient({
 client.login(<YOUR_DISCORD_TOKEN_HERE>);
 ```
 
-The `presence` option in the client's constructor allows you to configure the presence statuses to be used by the bots. These presence statuses may include information from the bot, such as: number of guilds connected to, number of commands, the time the bot went online, among others... Consider checking the [documentation page](https://docs.greencoaststudios.com/discord.js-extended/master/classes/discord_js_extended.presencetemplater.html) to see what information you can include in your presence statuses.
+The `presence` option in the client's constructor allows you to configure the presence statuses to be used by the bots. These presence statuses may include information from the bot, such as: number of guilds connected to, number of commands, the time the bot went online, or even custom data... Consider checking the [documentation page](https://docs.greencoaststudios.com/discord.js-extended/master/classes/discord_js_extended.presencetemplater.html) to see what information you can include in your presence statuses
+and how to add custom getters for your own presence messages.
 
 ### Adding defaults to your Client
 

--- a/__mocks__/discord.js.ts
+++ b/__mocks__/discord.js.ts
@@ -14,5 +14,6 @@ export default {
   MessageEmbed: DiscordMock.MessageEmbedMock,
   ShardClientUtil: DiscordMock.ShardClientUtilMock,
   Interaction: DiscordMock.InteractionMock,
-  Collection: RealDiscord.Collection
+  Collection: RealDiscord.Collection,
+  Permissions: RealDiscord.Permissions
 };

--- a/__mocks__/discordMocks.ts
+++ b/__mocks__/discordMocks.ts
@@ -40,6 +40,9 @@ export class ClientMock {
         reduce: (fn: any, initial: any) => {
           return [{ memberCount: 10 }, { memberCount: 5 }, { memberCount: 2 }].reduce(fn, initial);
         },
+        map: (fn: any) => {
+          return [{ id: '1' }, { id: '2' }, { id: '3' }].map(fn);
+        },
         size: 3
       }
     };
@@ -161,6 +164,7 @@ export class InteractionMock {
   public isCommand: jest.Mock;
   public inGuild: jest.Mock;
   public reply: jest.Mock;
+  public options: unknown;
 
   constructor() {
     this.guild = new GuildMock();
@@ -169,5 +173,8 @@ export class InteractionMock {
     this.isCommand = jest.fn();
     this.inGuild = jest.fn();
     this.reply = jest.fn();
+    this.options = {
+      getString: jest.fn()
+    };
   }
 }

--- a/__mocks__/locale.ts
+++ b/__mocks__/locale.ts
@@ -1,0 +1,17 @@
+export const mockedLocaleStrings = {
+  en: {
+    'message.test.hello': 'Hello',
+    'message.test.bye': 'Bye',
+    'message.test.with_value': 'Hello {name}!'
+  },
+  es: {
+    'message.test.hello': 'Hola',
+    'message.test.bye': 'Adios',
+    'message.test.with_value': 'Hola {name}!'
+  },
+  fr: {
+    'message.test.hello': 'Bonjour',
+    'message.test.bye': 'Au revoir',
+    'message.test.with_value': 'Bonjour {name}!'
+  }
+};

--- a/example/commands/slash/LocalizedSlashCommand.js
+++ b/example/commands/slash/LocalizedSlashCommand.js
@@ -1,0 +1,21 @@
+const { SlashCommand } = require('@greencoast/discord.js-extended');
+const { SlashCommandBuilder } = require('@discordjs/builders');
+
+class LocalizedSlashCommand extends SlashCommand {
+  constructor(client) {
+    super(client, {
+      name: 'localized',
+      description: 'Test localization.',
+      group: 'slash',
+      dataBuilder: new SlashCommandBuilder()
+    });
+  }
+
+  run(interaction) {
+    const localizer = this.client.localizer.getLocalizer(interaction.guild);
+
+    return interaction.reply(localizer.t('greetings.hello', { name: interaction.user.username }));
+  }
+}
+
+module.exports = LocalizedSlashCommand;

--- a/example/config/settings.json
+++ b/example/config/settings.json
@@ -1,3 +1,4 @@
 {
-  "prefix": "$"
+  "prefix": "$",
+  "my_enum": "enum1"
 }

--- a/example/index.js
+++ b/example/index.js
@@ -11,13 +11,23 @@ const config = new ConfigProvider({
   configPath: path.join(__dirname, './config/settings.json'),
   default: {
     PREFIX: '!',
-    OPTIONAL_NUMBER: null
+    OPTIONAL_NUMBER: null,
+    MY_ENUM: 'enum1'
   },
   types: {
     TOKEN: 'string',
     PREFIX: 'string',
     OPTIONAL_NUMBER: ['number', 'null'], // A DISCORD_OPTIONAL_NUMBER env variable which will be cast to a number. It also accepts "null" as value.
-    REQUIRED_BOOLEAN: 'boolean' // A DISCORD_REQUIRED_BOOLEAN env variable which will be cast to a boolean.
+    REQUIRED_BOOLEAN: 'boolean', // A DISCORD_REQUIRED_BOOLEAN env variable which will be cast to a boolean.
+    MY_ENUM: 'string' // A DISCORD_MY_ENUM env variable that will use a custom validator.
+  },
+  customValidators: {
+    MY_ENUM: (value) => {
+      const validValues = ['enum1', 'enum2', 'enum3'];
+      if (!validValues.includes(value)) {
+        throw new TypeError(`${value} is not a valid value for MY_ENUM, you should use: ${validValues.join(', ')}`);
+      }
+    }
   }
 });
 

--- a/example/index.js
+++ b/example/index.js
@@ -19,7 +19,8 @@ const config = new ConfigProvider({
     PREFIX: 'string',
     OPTIONAL_NUMBER: ['number', 'null'], // A DISCORD_OPTIONAL_NUMBER env variable which will be cast to a number. It also accepts "null" as value.
     REQUIRED_BOOLEAN: 'boolean', // A DISCORD_REQUIRED_BOOLEAN env variable which will be cast to a boolean.
-    MY_ENUM: 'string' // A DISCORD_MY_ENUM env variable that will use a custom validator.
+    MY_ENUM: 'string', // A DISCORD_MY_ENUM env variable that will use a custom validator.
+    MY_NUM_ARRAY: 'number[]' // A DISCORD_MY_NUM_ARRAY env variable with comma separated numbers that will turn into an array of numbers.
   },
   customValidators: {
     MY_ENUM: (value) => {
@@ -68,6 +69,8 @@ client.on('ready', async() => {
 
   await client.setDataProvider(dataProvider); // It would be recommended to set the data provider once the client is ready.
   await client.deployer.deployToTestingGuild(); // Deploy slash commands to the testing guild.
+
+  logger.info(`My numbers from the environment variable are: ${client.config.get('MY_NUM_ARRAY').join(', ')}`);
 });
 
 client.login(client.config.get('TOKEN'));

--- a/example/index.js
+++ b/example/index.js
@@ -4,6 +4,7 @@ const logger = require('@greencoast/logger');
 const { Intents } = require('discord.js');
 const { ExtendedClient, ConfigProvider } = require('@greencoast/discord.js-extended');
 const LevelDataProvider = require('@greencoast/discord.js-extended/dist/providers/LevelDataProvider').default;
+const locales = require('./locale');
 
 // The environment object contains the property: DISCORD_TOKEN with the bot's token.
 const config = new ConfigProvider({
@@ -48,7 +49,11 @@ const client = new ExtendedClient({
   config,
   errorOwnerReporting: true,
   intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.DIRECT_MESSAGES],
-  testingGuildID: '756628171494916098'
+  testingGuildID: '756628171494916098',
+  localizer: {
+    defaultLocale: 'en',
+    localeStrings: locales
+  }
 });
 
 const dataProvider = new LevelDataProvider(client, path.join(__dirname, './data'));
@@ -68,6 +73,7 @@ client.on('ready', async() => {
   logger.info(`Listening for commands with prefix: ${client.prefix}`);
 
   await client.setDataProvider(dataProvider); // It would be recommended to set the data provider once the client is ready.
+  await client.localizer.init(); // Initialize the localizer after setting up the data provider.
   await client.deployer.deployToTestingGuild(); // Deploy slash commands to the testing guild.
 
   logger.info(`My numbers from the environment variable are: ${client.config.get('MY_NUM_ARRAY').join(', ')}`);

--- a/example/index.js
+++ b/example/index.js
@@ -26,10 +26,13 @@ const client = new ExtendedClient({
   owner: '191330192868769793',
   debug: true,
   presence: {
-    templates: ['{num_guilds} guilds!', '{num_members} members!', 'owner: {owner_name}', '{uptime}', '{ready_time}'],
+    templates: ['{num_guilds} guilds!', 'random number {random}', '{num_members} members!', 'owner: {owner_name}', '{uptime}', '{ready_time}'],
     refreshInterval: 10000, // Presence gets changed every 10 seconds.
     status: 'dnd',
-    type: 'COMPETING'
+    type: 'COMPETING',
+    customGetters: {
+      random: async() => Math.random().toString()
+    }
   },
   config,
   errorOwnerReporting: true,

--- a/example/locale/en.js
+++ b/example/locale/en.js
@@ -1,0 +1,15 @@
+const GREETINGS = {
+  'greetings.hello': 'Hello {name}',
+  'greetings.hi': 'Hi!',
+  'greetings.bye': 'Bye',
+  'greetings.goodbye': 'Goodbye!'
+};
+
+const EXTRA = {
+  'extra.nice_weather': "It's {temperature}, it's a nice weather!"
+};
+
+module.exports = {
+  ...GREETINGS,
+  ...EXTRA
+};

--- a/example/locale/es.js
+++ b/example/locale/es.js
@@ -1,0 +1,15 @@
+const GREETINGS = {
+  'greetings.hello': 'Hola {name}',
+  'greetings.hi': '¡Hola!',
+  'greetings.bye': 'Chao',
+  'greetings.goodbye': '¡Adiós!'
+};
+
+const EXTRA = {
+  'extra.nice_weather': "¡La temperatura es de {temperature}, qué buen clima!"
+};
+
+module.exports = {
+  ...GREETINGS,
+  ...EXTRA
+};

--- a/example/locale/index.js
+++ b/example/locale/index.js
@@ -1,0 +1,7 @@
+const en = require('./en');
+const es = require('./es');
+
+module.exports = {
+  en,
+  es
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@greencoast/discord.js-extended",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@greencoast/discord.js-extended",
-      "version": "1.2.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@discordjs/builders": "^0.11.0",
@@ -16,6 +16,7 @@
         "dayjs": "^1.10.7",
         "discord-api-types": "^0.26.1",
         "humanize-duration": "^3.27.1",
+        "intl-messageformat": "^9.11.1",
         "lodash": "^4.17.21",
         "require-all": "^3.0.0"
       },
@@ -684,6 +685,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.1.tgz",
+      "integrity": "sha512-tgtNODZUGuUI6PAcnvaLZpGrZLVkXnnAvgzOiueYMzFdOdcOw4iH1WKhCe3+r6VR8rHKToJ2HksUGNCB+zt/bg==",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "0.2.22",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
+      "integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.16.tgz",
+      "integrity": "sha512-sYg0ImXsAqBbjU/LotoCD9yKC5nUpWVy3s4DwWerHXD4sm62FcjMF8mekwudRk3eZLHqSO+M21MpFUUjDQ+Q5Q==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.1",
+        "@formatjs/icu-skeleton-parser": "1.3.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.3.tgz",
+      "integrity": "sha512-ifWnzjmHPHUF89UpCvClTP66sXYFc8W/qg7Qt+qtTUB9BqRWlFeUsevAzaMYDJsRiOy4S2WJFrJoZgRKUFfPGQ==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.22.tgz",
+      "integrity": "sha512-z+TvbHW8Q/g2l7/PnfUl0mV9gWxV4d0HT6GQyzkO5QI6QjCvCZGiztnmLX7zoyS16uSMvZ2PoMDfSK9xvZkRRA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@greencoast/logger": {
@@ -4738,6 +4783,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.11.1.tgz",
+      "integrity": "sha512-kT0i8AIa1Aez8jGn1i9Xva/sdbjOPY15abR82qnU4jnESjxtynHLW1CBh9ehs13sPA8cE/4A2d6LEne91oDp4w==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.1",
+        "@formatjs/fast-memoize": "1.2.1",
+        "@formatjs/icu-messageformat-parser": "2.0.16",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/is-bigint": {
@@ -9854,6 +9910,50 @@
         }
       }
     },
+    "@formatjs/ecma402-abstract": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.1.tgz",
+      "integrity": "sha512-tgtNODZUGuUI6PAcnvaLZpGrZLVkXnnAvgzOiueYMzFdOdcOw4iH1WKhCe3+r6VR8rHKToJ2HksUGNCB+zt/bg==",
+      "requires": {
+        "@formatjs/intl-localematcher": "0.2.22",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@formatjs/fast-memoize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
+      "integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "@formatjs/icu-messageformat-parser": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.16.tgz",
+      "integrity": "sha512-sYg0ImXsAqBbjU/LotoCD9yKC5nUpWVy3s4DwWerHXD4sm62FcjMF8mekwudRk3eZLHqSO+M21MpFUUjDQ+Q5Q==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.11.1",
+        "@formatjs/icu-skeleton-parser": "1.3.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@formatjs/icu-skeleton-parser": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.3.tgz",
+      "integrity": "sha512-ifWnzjmHPHUF89UpCvClTP66sXYFc8W/qg7Qt+qtTUB9BqRWlFeUsevAzaMYDJsRiOy4S2WJFrJoZgRKUFfPGQ==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.11.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@formatjs/intl-localematcher": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.22.tgz",
+      "integrity": "sha512-z+TvbHW8Q/g2l7/PnfUl0mV9gWxV4d0HT6GQyzkO5QI6QjCvCZGiztnmLX7zoyS16uSMvZ2PoMDfSK9xvZkRRA==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "@greencoast/logger": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@greencoast/logger/-/logger-1.1.0.tgz",
@@ -12879,6 +12979,17 @@
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "intl-messageformat": {
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.11.1.tgz",
+      "integrity": "sha512-kT0i8AIa1Aez8jGn1i9Xva/sdbjOPY15abR82qnU4jnESjxtynHLW1CBh9ehs13sPA8cE/4A2d6LEne91oDp4w==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.11.1",
+        "@formatjs/fast-memoize": "1.2.1",
+        "@formatjs/icu-messageformat-parser": "2.0.16",
+        "tslib": "^2.1.0"
       }
     },
     "is-bigint": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "dayjs": "^1.10.7",
     "discord-api-types": "^0.26.1",
     "humanize-duration": "^3.27.1",
+    "intl-messageformat": "^9.11.1",
     "lodash": "^4.17.21",
     "require-all": "^3.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@greencoast/discord.js-extended",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "An utility to facilitate the repetitive tasks when creating discord bots. Used by Greencoast Studios.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/classes/ExtendedClient.ts
+++ b/src/classes/ExtendedClient.ts
@@ -6,6 +6,7 @@ import DataProvider from './data/DataProvider';
 import CommandRegistry from './command/CommandRegistry';
 import CommandDispatcher from './command/CommandDispatcher';
 import SlashCommandDeployer from './command/SlashCommandDeployer';
+import Localizer from './locale/Localizer';
 import ClientDefaultHandlers from './events/ClientDefaultHandlers';
 import ExtraClientDefaultHandlers from './events/ExtraClientDefaultHandlers';
 import ExtendedClientOptions from '../interfaces/ExtendedClientOptions';
@@ -84,6 +85,14 @@ export class ExtendedClient extends Discord.Client {
   public deployer: SlashCommandDeployer;
 
   /**
+   * This client's localizer. This value can be `null` if no `localizer` options are
+   * passed to this client's options.
+   * @type {Localizer}
+   * @memberof ExtendedClient
+   */
+  public localizer: Localizer | null;
+
+  /**
    * @param options The client's options. Defaults to an empty object.
    */
   // eslint-disable-next-line max-statements
@@ -107,6 +116,7 @@ export class ExtendedClient extends Discord.Client {
     this.registry = new CommandRegistry(this);
     this.dispatcher = new CommandDispatcher(this, this.registry);
     this.deployer = new SlashCommandDeployer(this);
+    this.localizer = options.localizer ? new Localizer(this, options.localizer) : null;
 
     this.fetchOwner();
     this.registerMessageHandler().registerInteractionHandler();

--- a/src/classes/abstract/AsyncTemplater.ts
+++ b/src/classes/abstract/AsyncTemplater.ts
@@ -22,7 +22,7 @@ abstract class AsyncTemplater {
    * Get the actual value that will replace the key inside the template.
    * @param key The key to replace.
    * @returns A promise that resolves to the corresponding string for the given key.
-   * @throws Throws if given key does not correspond to this async templater.
+   * @throws Rejects if given key does not correspond to this async templater.
    */
   public abstract get(key: string): Promise<string>;
 

--- a/src/classes/command/CommandRegistry.ts
+++ b/src/classes/command/CommandRegistry.ts
@@ -208,17 +208,20 @@ class CommandRegistry {
   /**
    * Register the default commands. **Default groups should be registered before using this.**
    * For more information, check out {@link DefaultCommands}.
+   * @param registerSlash If true it will register the default slash commands otherwise, the regular ones
+   * will be registered.
    * @returns This command registry.
    * @emits `client#commandRegistered`
    */
-  public registerDefaultCommands(): this {
-    this.registerCommands(Object.values(DefaultCommands).map((Command) => new Command(this.client)));
+  public registerDefaultCommands(registerSlash = true): this {
+    const defaults = registerSlash ? DefaultCommands.Slash : DefaultCommands.Regular;
+    this.registerCommands(Object.values(defaults).map((Command) => new Command(this.client)));
 
     return this;
   }
 
   /**
-   * Register both the default groups and default commands in the correct order.
+   * Register both the default groups and default slash commands in the correct order.
    * @returns This command registry.
    * @emits `client#groupRegistered`
    * @emits `client#commandRegistered`

--- a/src/classes/command/CommandRegistry.ts
+++ b/src/classes/command/CommandRegistry.ts
@@ -192,12 +192,14 @@ class CommandRegistry {
    * | ID of the group | Name of the group        |
    * |-----------------|--------------------------|
    * | `misc`          | `Miscellaneous Commands` |
+   * | `config`        | `Configuration Commands` |
    * @returns This command registry.
    * @emits `client#groupRegistered`
    */
   public registerDefaultGroups(): this {
     this.registerGroups([
-      ['misc', 'Miscellaneous Commands']
+      ['misc', 'Miscellaneous Commands'],
+      ['config', 'Configuration Commands']
     ]);
 
     return this;

--- a/src/classes/command/default/SetLocaleCommand.ts
+++ b/src/classes/command/default/SetLocaleCommand.ts
@@ -1,0 +1,54 @@
+import Discord from 'discord.js';
+import { SlashCommandBuilder } from '@discordjs/builders';
+import SlashCommand from '../SlashCommand';
+import ExtendedClient from '../../ExtendedClient';
+
+/**
+ * The default set locale command. This command is part of the `config` group.
+ *
+ * This command updates the locale for the current guild.
+ * @category config - Configuration Commands
+ */
+class SetLocale extends SlashCommand {
+  /**
+   * @param client The client that this command will be used by.
+   */
+  constructor(client: ExtendedClient) {
+    super(client, {
+      name: 'set_locale',
+      emoji: ':earth_americas:',
+      group: 'config',
+      description: 'Update the locale for this guild.',
+      guildOnly: true,
+      userPermissions: [Discord.Permissions.FLAGS.MANAGE_GUILD],
+      dataBuilder: new SlashCommandBuilder().addStringOption((input) => {
+        return input
+          .setName('locale')
+          .setDescription('The new locale to be used.')
+          .setRequired(true);
+      }) as SlashCommandBuilder
+    });
+  }
+
+  /**
+   * Run the set locale command. Usage:
+   * ```text
+   * /set_locale <locale>
+   * ```
+   * @param interaction The [interaction](https://discord.js.org/#/docs/discord.js/stable/class/CommandInteraction) that triggered this command.
+   */
+  public async run(interaction: Discord.CommandInteraction): Promise<void> {
+    const localizer = this.client.localizer!.getLocalizer(interaction.guild!)!; // We know it comes from a guild because of guildOnly.
+    const newLocale = interaction.options.getString('locale')!; // We know it's not null because it is required.
+
+    if (newLocale === localizer.locale) {
+      await interaction.reply(`Locale is already set to ${localizer.locale}.`);
+      return;
+    }
+
+    await localizer.updateLocale(newLocale); // Failure caught by onError.
+    await interaction.reply(`Successfully updated locale to ${newLocale}.`);
+  }
+}
+
+export default SetLocale;

--- a/src/classes/command/default/index.ts
+++ b/src/classes/command/default/index.ts
@@ -5,7 +5,9 @@
  */
 
 import HelpCommand from './HelpCommand';
+import SetLocaleCommand from './SetLocaleCommand';
 
 export {
-  HelpCommand
+  HelpCommand,
+  SetLocaleCommand
 };

--- a/src/classes/command/default/index.ts
+++ b/src/classes/command/default/index.ts
@@ -4,10 +4,18 @@
  * @module DefaultCommands
  */
 
-import HelpCommand from './HelpCommand';
-import SetLocaleCommand from './SetLocaleCommand';
+import HelpRegularCommand from './regular/HelpRegularCommand';
+import SetLocaleRegularCommand from './regular/SetLocaleRegularCommand';
 
-export {
-  HelpCommand,
-  SetLocaleCommand
+import HelpSlashCommand from './slash/HelpSlashCommand';
+import SetLocaleSlashCommand from './slash/SetLocaleSlashCommand';
+
+export const Regular = {
+  HelpRegularCommand,
+  SetLocaleRegularCommand
+};
+
+export const Slash = {
+  HelpSlashCommand,
+  SetLocaleSlashCommand
 };

--- a/src/classes/command/default/regular/HelpRegularCommand.ts
+++ b/src/classes/command/default/regular/HelpRegularCommand.ts
@@ -1,25 +1,25 @@
 import Discord from 'discord.js';
-import RegularCommand from '../RegularCommand';
-import ExtendedClient from '../../ExtendedClient';
+import RegularCommand from '../../RegularCommand';
+import ExtendedClient from '../../../ExtendedClient';
 
 /**
- * The default help message. This command is part of the `misc` group.
+ * The default help message. This regular command is part of the `misc` group.
  *
  * The help message will look like this: ![Preview](https://i.imgur.com/y0ffAjN.png)
  * @category misc - Miscellaneous Commands
  */
-class HelpCommand extends RegularCommand {
+class HelpRegularCommand extends RegularCommand {
   /**
    * The color of the embed for the help message.
    * @type {Discord.ColorResolvable}
-   * @memberof HelpCommand
+   * @memberof HelpRegularCommand
    */
   public embedColor: Discord.ColorResolvable;
 
   /**
    * The thumbnail of the embed for the help message.
    * @type {string}
-   * @memberof HelpCommand
+   * @memberof HelpRegularCommand
    */
   public embedThumbnail: string;
 
@@ -80,4 +80,4 @@ class HelpCommand extends RegularCommand {
   }
 }
 
-export default HelpCommand;
+export default HelpRegularCommand;

--- a/src/classes/command/default/regular/SetLocaleRegularCommand.ts
+++ b/src/classes/command/default/regular/SetLocaleRegularCommand.ts
@@ -1,0 +1,51 @@
+import Discord from 'discord.js';
+import RegularCommand from '../../RegularCommand';
+import ExtendedClient from '../../../ExtendedClient';
+
+/**
+ * The default set locale command. This regular command is part of the `config` group.
+ *
+ * This command updates the locale for the current guild.
+ * @category config - Configuration Commands
+ */
+class SetLocaleRegularCommand extends RegularCommand {
+  /**
+   * @param client The client that this command will be used by.
+   */
+  constructor(client: ExtendedClient) {
+    super(client, {
+      name: 'set_locale',
+      emoji: ':earth_americas:',
+      group: 'config',
+      description: 'Update the locale for this guild.',
+      guildOnly: true,
+      userPermissions: [Discord.Permissions.FLAGS.MANAGE_GUILD]
+    });
+  }
+
+  /**
+   * Run the set locale command. Usage:
+   * ```text
+   * /set_locale <locale>
+   * ```
+   * @param message The [message](https://discord.js.org/#/docs/discord.js/stable/class/Message) that triggered this command.
+   * @param args The arguments passed to this command.
+   */
+  public async run(message: Discord.Message, args: string[]): Promise<Discord.Message> {
+    const localizer = this.client.localizer!.getLocalizer(message.guild!)!; // We know it comes from a guild because of guildOnly.
+    const [newLocale] = args;
+
+    if (!newLocale) {
+      return message.reply('You need to specify a locale.');
+    }
+
+    if (newLocale === localizer.locale) {
+      return message.reply(`Locale is already set to ${localizer.locale}.`);
+    }
+
+    await localizer.updateLocale(newLocale); // Failure caught by onError.
+    return message.reply(`Successfully updated locale to ${newLocale}.`);
+  }
+}
+
+export default SetLocaleRegularCommand;

--- a/src/classes/command/default/slash/HelpSlashCommand.ts
+++ b/src/classes/command/default/slash/HelpSlashCommand.ts
@@ -1,0 +1,84 @@
+import Discord from 'discord.js';
+import { SlashCommandBuilder } from '@discordjs/builders';
+import SlashCommand from '../../SlashCommand';
+import ExtendedClient from '../../../ExtendedClient';
+
+/**
+ * The default help message. This slash command is part of the `misc` group.
+ *
+ * The help message will look like this: ![Preview](https://i.imgur.com/y0ffAjN.png)
+ * @category misc - Miscellaneous Commands
+ */
+class HelpSlashCommand extends SlashCommand {
+  /**
+   * The color of the embed for the help message.
+   * @type {Discord.ColorResolvable}
+   * @memberof HelpRegularCommand
+   */
+  public embedColor: Discord.ColorResolvable;
+
+  /**
+   * The thumbnail of the embed for the help message.
+   * @type {string}
+   * @memberof HelpRegularCommand
+   */
+  public embedThumbnail: string;
+
+  /**
+   * @param client The client that this command will be used by.
+   */
+  constructor(client: ExtendedClient) {
+    super(client, {
+      name: 'help',
+      emoji: ':question:',
+      group: 'misc',
+      description: 'Get a description of all the commands that this bot can run.',
+      guildOnly: false,
+      ownerOnly: false,
+      dataBuilder: new SlashCommandBuilder()
+    });
+
+    this.embedColor = '#43aa8b';
+    this.embedThumbnail = 'https://i.imgur.com/Tqnk48j.png';
+  }
+
+  /**
+   * Prepare the fields that will be added to the embed based on all the commands registered on the client.
+   * The title of the field will be the group's name and the text will be the list of commands.
+   * @returns An array of objects that contain the field's title and text.
+   */
+  public prepareFields(): { title: string, text: string }[] {
+    return this.client.registry.groups.map((group) => {
+      const listOfCommands = group.commands.reduce((text, command) => {
+        return text.concat(`${command.emoji} **/${command.name}** - ${command.description}\n`);
+      }, '');
+
+      return { title: group.name, text: listOfCommands };
+    });
+  }
+
+  /**
+   * Run the help command. Usage:
+   * ```text
+   * $help
+   * ```
+   * @param interaction The [interaction](https://discord.js.org/#/docs/discord.js/stable/class/CommandInteraction) that triggered this command.
+   */
+  public async run(interaction: Discord.CommandInteraction): Promise<void> {
+    const embed = new Discord.MessageEmbed();
+    const fields = this.prepareFields();
+
+    embed.setTitle('Command List and Help');
+    embed.setColor(this.embedColor);
+    embed.setThumbnail(this.embedThumbnail);
+
+    for (const key in fields) {
+      const field = fields[key];
+      embed.addField(field.title, field.text);
+    }
+
+    return interaction.reply({ embeds: [embed] });
+  }
+}
+
+export default HelpSlashCommand;

--- a/src/classes/command/default/slash/SetLocaleSlashCommand.ts
+++ b/src/classes/command/default/slash/SetLocaleSlashCommand.ts
@@ -1,15 +1,15 @@
 import Discord from 'discord.js';
 import { SlashCommandBuilder } from '@discordjs/builders';
-import SlashCommand from '../SlashCommand';
-import ExtendedClient from '../../ExtendedClient';
+import SlashCommand from '../../SlashCommand';
+import ExtendedClient from '../../../ExtendedClient';
 
 /**
- * The default set locale command. This command is part of the `config` group.
+ * The default set locale command. This slash command is part of the `config` group.
  *
  * This command updates the locale for the current guild.
  * @category config - Configuration Commands
  */
-class SetLocale extends SlashCommand {
+class SetLocaleSlashCommand extends SlashCommand {
   /**
    * @param client The client that this command will be used by.
    */
@@ -51,4 +51,4 @@ class SetLocale extends SlashCommand {
   }
 }
 
-export default SetLocale;
+export default SetLocaleSlashCommand;

--- a/src/classes/config/ConfigProvider.ts
+++ b/src/classes/config/ConfigProvider.ts
@@ -19,11 +19,18 @@ import { ConfigValue } from '../../types';
  *
  * > If config is repeated on multiple sources, they'll be overwritten by the latest config source.
  *
+ * The ConfigProvider supports array types, you can supply them through the JSON config as a direct array
+ * or through environment variables through comma-separated values.
+ *
+ * > Comma escaping is not supported yet, so if you specify a type of `string[]` and insert the value `Hi, my name is.`,
+ * > the value will correspond to `['Hi', ' my name is.']`.
+ *
  * An example environment variable file would be:
  *
  * ```text
  * DISCORD_TOKEN=MY_TOKEN
  * DISCORD_MY_VARIABLE=$
+ * DISCORD_MY_NUMS=123,234,345
  * ```
  *
  * An example JSON config file would be:
@@ -31,7 +38,8 @@ import { ConfigValue } from '../../types';
  * ```json
  * {
  *   "token": "MY_TOKEN",
- *   "my_variable": "$"
+ *   "my_variable": "$",
+ *   "my_nums": [123, 234, 345]
  * }
  * ```
  *
@@ -40,7 +48,8 @@ import { ConfigValue } from '../../types';
  * ```js
  * {
  *   TOKEN: 'MY_TOKEN',
- *   MY_VARIABLE: '$'
+ *   MY_VARIABLE: '$',
+ *   MY_NUMS: [1, 2, 3]
  * }
  * ```
  *
@@ -49,6 +58,7 @@ import { ConfigValue } from '../../types';
  * ```js
  * const token = client.config.get('TOKEN');
  * const myVariable = client.config.get('MY_VARIABLE');
+ * const myNums = client.config.get('MY_NUMS');
  * ```
  *
  * It is also recommended specifying the types of the config. Check {@link ConfigValidator} for more information.
@@ -84,6 +94,7 @@ class ConfigProvider {
 
   /**
    * @param options The options for this config provider.
+   * @throws Throws if it is not possible to cast a value to its given type.
    */
   constructor(options: ConfigProviderOptions = {}) {
     this.options = options;
@@ -141,6 +152,7 @@ class ConfigProvider {
    * Process the environment variables object for configuration.
    * Keys must begin with DISCORD_ to be added to the configuration provider.
    * @param env The environment variables object.
+   * @throws Throws if it is not possible to cast a value to its given type.
    */
   private processEnv(env?: Record<string, ConfigValue>): void {
     if (!env) {

--- a/src/classes/config/ConfigProvider.ts
+++ b/src/classes/config/ConfigProvider.ts
@@ -89,7 +89,7 @@ class ConfigProvider {
     this.options = options;
     this.default = options.default;
     this.config = {};
-    this.validator = new ConfigValidator(options.types || {});
+    this.validator = new ConfigValidator(options.types || {}, options.customValidators || {});
 
     this.processDefaults(options.default);
     this.processConfigFile(options.configPath);

--- a/src/classes/locale/GuildLocalizer.ts
+++ b/src/classes/locale/GuildLocalizer.ts
@@ -1,0 +1,125 @@
+import Discord from 'discord.js';
+import Localizer from './Localizer';
+
+/**
+ * A class to help with localization of your bot. This handles string translation from the context of the
+ * guild. For more information, check {@link Localizer}.
+ */
+class GuildLocalizer {
+  /**
+   * The main localizer for this guild localizer.
+   * @type {Localizer}
+   * @memberof {GuildLocalizer}
+   */
+  public readonly localizer: Localizer;
+
+  /**
+   * The guild that corresponds to this guild localizer.
+   * @type {Discord.Guild}
+   * @memberof {GuildLocalizer}
+   */
+  public readonly guild: Discord.Guild;
+
+  /**
+   * The key to be used to save the guild's locale in the client's
+   * data provider.
+   * @type {string}
+   * @default `locale`
+   * @memberof {GuildLocalizer}
+   */
+  public readonly dataProviderKey: string;
+
+  /**
+   * The current locale set for the guild. Do not update this value manually, instead use
+   * the `updateLocale()` method.
+   * @type {string}
+   * @memberof {GuildLocalizer}
+   */
+  public locale: string;
+
+  /**
+   * @param localizer The main localizer for this guild localizer.
+   * @param guild The guild that corresponds to this guild localizer.
+   */
+  constructor(localizer: Localizer, guild: Discord.Guild) {
+    this.localizer = localizer;
+    this.guild = guild;
+
+    this.dataProviderKey = localizer.options.dataProviderKey || 'locale';
+
+    this.locale = localizer.defaultLocale;
+  }
+
+  /**
+   * Initializes this guild localizer.
+   * You should call this after initializing the client's data provider since this method
+   * will read the locale set for each guild and will initialize their localizer with that value.
+   * @returns A promise that resolves to the locale set for this guild localizer.
+   * @throws Rejects if a guild localizer was being initialized with an unsupported locale retrieved
+   * from the data provider. This may happen if the locale saved in the data provider was updated manually.
+   */
+  public async init(): Promise<string> {
+    if (!this.localizer.client.dataProvider) {
+      return this.locale;
+    }
+
+    const savedLocale = await this.localizer.client.dataProvider.get(this.guild, this.dataProviderKey, this.locale);
+
+    if (!this.localizer.isLocaleSupported(savedLocale)) {
+      throw new Error(`Invalid locale ${savedLocale} received from data provider. Perhaps you changed the value for ${this.dataProviderKey} manually?`);
+    }
+
+    this.locale = savedLocale;
+
+    return this.locale;
+  }
+
+  /**
+   * Updates the locale set to this guild localizer. If the client has a data provider, it will also update
+   * the locale in it for persistence.
+   * @param locale The new locale to be used by this guild localizer.
+   * @returns A promise that resolves once the locale has been updated.
+   * @throws Rejects if the given locale is not supported.
+   */
+  public async updateLocale(locale: string): Promise<void> {
+    if (!this.localizer.isLocaleSupported(locale)) {
+      throw new Error(`${locale} is not a supported locale.`);
+    }
+
+    this.locale = locale;
+
+    if (!this.localizer.client.dataProvider) {
+      return;
+    }
+
+    return this.localizer.client.dataProvider.set(this.guild, this.dataProviderKey, this.locale);
+  }
+
+  /**
+   * Get the message for the given key translated into the locale of this
+   * guild localizer. You can also supply an object
+   * containing the dynamic values to be used.
+   * @param key The key of the message to translate.
+   * @param values The dynamic values to be replaced in the message.
+   * @returns The translated message.
+   * @throws Throws if the key does not resolve to any message.
+   * @throws Throws if the given locale is not supported.
+   */
+  public translate(key: string, values = {}): string {
+    return this.localizer.translate(key, this.locale, values);
+  }
+
+  /**
+   * Alias for `translate()`.
+   * @param key The key of the message to translate.
+   * @param values The dynamic values to be replaced in the message.
+   * @returns The translated message.
+   * @throws Throws if the key does not resolve to any message.
+   * @throws Throws if the given locale is not supported.
+   */
+  public t(key: string, values = {}): string {
+    return this.translate(key, values);
+  }
+}
+
+export default GuildLocalizer;

--- a/src/classes/locale/Localizer.ts
+++ b/src/classes/locale/Localizer.ts
@@ -1,0 +1,188 @@
+import Discord from 'discord.js';
+import IntlMessageFormat from 'intl-messageformat';
+import ExtendedClient from '../ExtendedClient';
+import GuildLocalizer from './GuildLocalizer';
+import LocalizerOptions from '../../interfaces/LocalizerOptions';
+
+/**
+ * A class to help with the localization of your bot. This handles string translation based on the
+ * [intl-messageformat](https://formatjs.io/docs/intl-messageformat/) package. Strings are defined in
+ * [ICU](https://formatjs.io/docs/intl-messageformat/#common-usage-example) format and dynamic values inside.
+ * It is recommended to have a data provider set in the client for the locale settings to be saved
+ * persistently for each guild.
+ */
+class Localizer {
+  /**
+   * The client that this localizer will be used by.
+   * @type {ExtendedClient}
+   * @memberof Localizer
+   */
+  public readonly client: ExtendedClient;
+
+  /**
+   * An object that maps the name of the locale to another object that contains
+   * all the available messages mapped by their keys. The messages should follow
+   * a ICU standard, for more information on how to structure these messages, please visit the
+   * [following link](https://formatjs.io/docs/intl-messageformat/#common-usage-example).
+   *
+   * The following is an example of how to structure this object:
+   *
+   * en: {
+   *   'message.test.hello': 'Hello',
+   *   'message.test.bye': 'Bye',
+   *   'message.test.with_value': 'Hello {name}!'
+   * },
+   * es: {
+   *   'message.test.hello': 'Hola',
+   *   'message.test.bye': 'Adios',
+   *   'message.test.with_value': 'Hola {name}!'
+   * },
+   * fr: {
+   *   'message.test.hello': 'Bonjour',
+   *   'message.test.bye': 'Au revoir',
+   *   'message.test.with_value': 'Bonjour {name}!'
+   * }
+   * @type {Record<string, Record<string, string>>}
+   * @memberof {Localizer}
+   */
+  public readonly localeStrings: Record<string, Record<string, string>>;
+
+  /**
+   * The default locale to be used in case a guild does not have its locale set in the
+   * client's data provider. You should set a data provider before setting this up so
+   * the guild's locale can be saved persistently.
+   * @type {string}
+   * @memberof {Localizer}
+   */
+  public readonly defaultLocale: string;
+
+  /**
+   * The options for this localizer.
+   * @type {LocalizerOptions}
+   * @memberof {Localizer}
+   */
+  public readonly options: LocalizerOptions;
+
+  /**
+   * The {@link GuildLocalizer}s for each guild.
+   * @type {Discord.Collection<Discord.Snowflake, GuildLocalizer>}
+   * @memberof {Localizer}
+   */
+  public readonly guildLocalizers: Discord.Collection<Discord.Snowflake, GuildLocalizer>;
+
+  /**
+   * @param client The client that this localizer will be used by.
+   * @param options The options for this localizer.
+   * @throws Throws if the supplied default locale is not supported.
+   */
+  constructor(client: ExtendedClient, options: LocalizerOptions) {
+    this.client = client;
+    this.localeStrings = options.localeStrings;
+
+    if (!this.isLocaleSupported(options.defaultLocale)) {
+      throw new Error(`${options.defaultLocale} is not a supported locale.`);
+    }
+
+    this.defaultLocale = options.defaultLocale;
+    this.options = options;
+    this.guildLocalizers = new Discord.Collection();
+  }
+
+  /**
+   * Initializes all the {@link GuildLocalizer}s for each guild the client is connected to.
+   * You should call this after initializing the client's data provider since this method
+   * will read the locale set for each guild and will initialize their localizer with that value.
+   * In case the client does not have a data provider, you should still call this method, but the
+   * localizers will be initialized with the default locale.
+   * @returns A promise that resolves once all guild localizers are ready.
+   * @throws Rejects if a guild localizer was being initialized with an unsupported locale retrieved
+   * from the data provider. This may happen if the locale saved in the data provider was updated manually.
+   */
+  public init(): Promise<string[]> {
+    return Promise.all(this.client.guilds.cache.map((guild) => {
+      const localizer = new GuildLocalizer(this, guild);
+      this.guildLocalizers.set(guild.id, localizer);
+
+      return localizer.init();
+    }));
+  }
+
+  /**
+   * Get the localizer for the given guild.
+   * @param guild
+   * @returns The guild localizer for the given guild.
+   */
+  public getLocalizer(guild: Discord.Guild): GuildLocalizer | undefined {
+    return this.guildLocalizers.get(guild.id);
+  }
+
+  /**
+   * Get a list of all the available locales retrieved based on the keys of `localeStrings`.
+   * @returns An array containing all the available locales.
+   */
+  public getAvailableLocales(): string[] {
+    return Object.keys(this.localeStrings);
+  }
+
+  /**
+   * Check whether the given locale is supported.
+   * @param locale The locale to test.
+   * @returns `true` if the locale is supported.
+   */
+  public isLocaleSupported(locale: string): boolean {
+    return this.getAvailableLocales().includes(locale);
+  }
+
+  /**
+   * Get the message for the given key translated into the given locale. You can also supply an object
+   * containing the dynamic values to be used.
+   * @param key The key of the message to translate.
+   * @param locale The locale to translate the message to.
+   * @param values The dynamic values to be replaced in the message.
+   * @returns The translated message.
+   * @throws Throws if the key does not resolve to any message.
+   * @throws Throws if the given locale is not supported.
+   */
+  public translate(key: string, locale?: string | null, values = {}): string {
+    return this.getMessage(key, locale || this.defaultLocale).format(values) as string;
+  }
+
+  /**
+   * Alias for `translate()`.
+   * @param key The key of the message to translate.
+   * @param locale The locale to translate the message to.
+   * @param values The dynamic values to be replaced in the message.
+   * @returns The translated message.
+   * @throws Throws if the key does not resolve to any message.
+   * @throws Throws if the given locale is not supported.
+   */
+  public t(key: string, locale?: string | null, values = {}): string {
+    return this.translate(key, locale, values);
+  }
+
+  /**
+   * Get the formatter object to format the message of the given key and locale.
+   * @param key The key of the message to translate.
+   * @param locale The locale to translate the message to.
+   * @returns The formatter object for translating the message.
+   * @throws Throws if the key does not resolve to any message.
+   * @throws Throws if the given locale is not supported.
+   */
+  private getMessage(key: string, locale: string): IntlMessageFormat {
+    const messagesForLocale = this.localeStrings[locale];
+
+    if (!messagesForLocale) {
+      throw new Error(`No messages with locale ${locale} exist!`);
+    }
+
+    const message = messagesForLocale[key];
+
+    if (!message) {
+      throw new Error(`No message with key ${key} for locale ${locale} exists!`);
+    }
+
+    return new IntlMessageFormat(this.localeStrings[locale][key]);
+  }
+}
+
+export default Localizer;

--- a/src/classes/presence/PresenceManager.ts
+++ b/src/classes/presence/PresenceManager.ts
@@ -52,9 +52,6 @@ class PresenceManager {
    * @param options The options for this presence manager.
    */
   constructor(client: ExtendedClient, options: PresenceManagerOptions = {}) {
-    this.client = client;
-    this.templater = new PresenceTemplater(client);
-
     if (!options.templates) {
       options.templates = ['{num_guilds} servers!'];
     }
@@ -67,6 +64,13 @@ class PresenceManager {
     if (!options.afk) {
       options.afk = false;
     }
+    if (!options.customGetters) {
+      options.customGetters = {};
+    }
+
+    this.client = client;
+    this.templater = new PresenceTemplater(client, options.customGetters);
+
     this.options = options;
     this.refreshIntervalHandle = null;
 

--- a/src/classes/presence/PresenceTemplater.ts
+++ b/src/classes/presence/PresenceTemplater.ts
@@ -1,10 +1,11 @@
-import Discord, { Snowflake } from 'discord.js';
+import Discord from 'discord.js';
 import humanizeDuration from 'humanize-duration';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 import ExtendedClient from '../ExtendedClient';
 import AsyncTemplater from '../abstract/AsyncTemplater';
+import { PresenceTemplaterGetters } from '../../types';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -35,9 +36,19 @@ class PresenceTemplater extends AsyncTemplater {
   public readonly client: ExtendedClient;
 
   /**
-   * @param client The client that this presence async templater will use as a data source.
+   * An object to map a templater key to a custom getter. The getter function
+   * should return a Promise that resolves to the correct string that the
+   * templater should replace the key with.
+   * @type {PresenceTemplaterGetters}
+   * @memberof PresenceTemplater
    */
-  constructor(client: ExtendedClient) {
+  public customGetters: PresenceTemplaterGetters;
+
+  /**
+   * @param client The client that this presence async templater will use as a data source.
+   * @param customGetters The custom getters object to define custom templates.
+   */
+  constructor(client: ExtendedClient, customGetters: PresenceTemplaterGetters) {
     super([
       'num_guilds',
       'prefix',
@@ -47,13 +58,17 @@ class PresenceTemplater extends AsyncTemplater {
       'uptime',
       'ready_time',
       'num_members',
-      'num_commands'
+      'num_commands',
+      ...Object.keys(customGetters)
     ]);
 
     this.client = client;
+    this.customGetters = customGetters;
   }
 
   public get(key: string): Promise<string> {
+    let getter: (() => Promise<string>) | undefined;
+
     switch (key) {
       case 'num_guilds':
         return this.getNumberOfGuilds();
@@ -74,6 +89,12 @@ class PresenceTemplater extends AsyncTemplater {
       case 'num_commands':
         return this.getNumberOfCommands();
       default:
+        getter = this.customGetters[key];
+
+        if (getter) {
+          return getter();
+        }
+
         return Promise.reject(new Error('Unknown key inserted in PresenceTemplater.'));
     }
   }
@@ -171,7 +192,7 @@ class PresenceTemplater extends AsyncTemplater {
 
     return this.client.shard.fetchClientValues('guilds.cache')
       .then((results) => {
-        const castedResults = results as Discord.Collection<Snowflake, Discord.Guild>[];
+        const castedResults = results as Discord.Collection<Discord.Snowflake, Discord.Guild>[];
         return castedResults.reduce((sum, guildCache) => {
           const memberCounts = guildCache.reduce((sum: number, guild: Discord.Guild) => sum + guild.memberCount, 0);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,8 @@ import CommandGroup from './classes/command/CommandGroup';
 import CommandRegistry from './classes/command/CommandRegistry';
 import CommandDispatcher from './classes/command/CommandDispatcher';
 import SlashCommandDeployer from './classes/command/SlashCommandDeployer';
+import Localizer from './classes/locale/Localizer';
+import GuildLocalizer from './classes/locale/GuildLocalizer';
 
 import * as DefaultCommands from './classes/command/default';
 
@@ -30,6 +32,7 @@ import PresenceData from './interfaces/PresenceData';
 import ConfigProviderOptions from './interfaces/ConfigProviderOptions';
 import CommandInfo from './interfaces/CommandInfo';
 import SlashCommandInfo from './interfaces/SlashCommandInfo';
+import LocalizerOptions from './interfaces/LocalizerOptions';
 
 import { ConfigValue, ConfigCustomValidators, CommandTrigger, PresenceTemplaterGetters } from './types';
 
@@ -52,6 +55,8 @@ export {
   CommandRegistry,
   CommandDispatcher,
   SlashCommandDeployer,
+  Localizer,
+  GuildLocalizer,
   DefaultCommands,
   ExtendedClientOptions,
   ExtendedClientEvents,
@@ -60,6 +65,7 @@ export {
   ConfigProviderOptions,
   CommandInfo,
   SlashCommandInfo,
+  LocalizerOptions,
   ConfigValue,
   ConfigCustomValidators,
   CommandTrigger,

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import ConfigProviderOptions from './interfaces/ConfigProviderOptions';
 import CommandInfo from './interfaces/CommandInfo';
 import SlashCommandInfo from './interfaces/SlashCommandInfo';
 
-import { ConfigValue, CommandTrigger } from './types';
+import { ConfigValue, CommandTrigger, PresenceTemplaterGetters } from './types';
 
 export {
   ExtendedClient,
@@ -61,5 +61,6 @@ export {
   CommandInfo,
   SlashCommandInfo,
   ConfigValue,
-  CommandTrigger
+  CommandTrigger,
+  PresenceTemplaterGetters
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import ConfigProviderOptions from './interfaces/ConfigProviderOptions';
 import CommandInfo from './interfaces/CommandInfo';
 import SlashCommandInfo from './interfaces/SlashCommandInfo';
 
-import { ConfigValue, CommandTrigger, PresenceTemplaterGetters } from './types';
+import { ConfigValue, ConfigCustomValidators, CommandTrigger, PresenceTemplaterGetters } from './types';
 
 export {
   ExtendedClient,
@@ -61,6 +61,7 @@ export {
   CommandInfo,
   SlashCommandInfo,
   ConfigValue,
+  ConfigCustomValidators,
   CommandTrigger,
   PresenceTemplaterGetters
 };

--- a/src/interfaces/ConfigProviderOptions.ts
+++ b/src/interfaces/ConfigProviderOptions.ts
@@ -1,4 +1,4 @@
-import { ConfigValue } from '../types';
+import { ConfigCustomValidators, ConfigValue } from '../types';
 
 /**
  * The config provider's options object. This defines where the config will be pulled from
@@ -29,7 +29,16 @@ interface ConfigProviderOptions {
    * It can be a string or an array of strings.
    * Types can be: `boolean`, `number`, `string`, or `null`.
    */
-  types?: Record<string, string | string[]>
+  types?: Record<string, string | string[]>,
+
+  /**
+   * An object that maps a config key to a custom validator function.
+   * This validator function will be used to validate the config supplied.
+   * It will skip the default type validator and instead use the one specified here.
+   * This function should not return anything, but throw a TypeError if the given value is not
+   * correct.
+   */
+  customValidators?: ConfigCustomValidators
 }
 
 export default ConfigProviderOptions;

--- a/src/interfaces/ExtendedClientOptions.ts
+++ b/src/interfaces/ExtendedClientOptions.ts
@@ -1,6 +1,7 @@
 import Discord from 'discord.js';
 import ConfigProvider from '../classes/config/ConfigProvider';
 import PresenceManagerOptions from './PresenceManagerOptions';
+import LocalizerOptions from './LocalizerOptions';
 
 /**
  * The options used to create a {@link ExtendedClient}.
@@ -47,7 +48,12 @@ interface ExtendedClientOptions extends Discord.ClientOptions {
    * it is recommended to specify one. This is used to automatically deploy
    * slash commands to the testing guild.
    */
-  testingGuildID?: string
+  testingGuildID?: string,
+
+  /**
+   * The client's localizer's options.
+   */
+  localizer?: LocalizerOptions
 }
 
 export default ExtendedClientOptions;

--- a/src/interfaces/LocalizerOptions.ts
+++ b/src/interfaces/LocalizerOptions.ts
@@ -1,0 +1,46 @@
+/**
+ * The options used to create a {@link Localizer}.
+ */
+interface LocalizerOptions {
+  /**
+   * An object that maps the name of the locale to another object that contains
+   * all the available messages mapped by their keys. The messages should follow
+   * a ICU standard, for more information on how to structure these messages, please visit the
+   * [following link](https://formatjs.io/docs/intl-messageformat/#common-usage-example).
+   *
+   * The following is an example of how to structure this object:
+   *
+   * en: {
+   *   'message.test.hello': 'Hello',
+   *   'message.test.bye': 'Bye',
+   *   'message.test.with_value': 'Hello {name}!'
+   * },
+   * es: {
+   *   'message.test.hello': 'Hola',
+   *   'message.test.bye': 'Adios',
+   *   'message.test.with_value': 'Hola {name}!'
+   * },
+   * fr: {
+   *   'message.test.hello': 'Bonjour',
+   *   'message.test.bye': 'Au revoir',
+   *   'message.test.with_value': 'Bonjour {name}!'
+   * }
+   */
+  localeStrings: Record<string, Record<string, string>>,
+
+  /**
+   * The default locale to be used in case a guild does not have its locale set in the
+   * client's data provider. You should set a data provider before setting this up so
+   * the guild's locale can be saved persistently.
+   */
+  defaultLocale: string,
+
+  /**
+   * The key used to save the value of the locale set per guild in the client's data provider
+   * (if any).
+   * @defaultValue `locale`
+   */
+  dataProviderKey?: string
+}
+
+export default LocalizerOptions;

--- a/src/interfaces/PresenceManagerOptions.ts
+++ b/src/interfaces/PresenceManagerOptions.ts
@@ -1,4 +1,5 @@
 import PresenceData from './PresenceData';
+import { PresenceTemplaterGetters } from '../types';
 
 /**
  * The presence manager's options.
@@ -14,7 +15,15 @@ interface PresenceManagerOptions extends PresenceData {
   /**
    * The interval at which the client's presence should be updated.
    */
-  refreshInterval?: number | null
+  refreshInterval?: number | null,
+
+  /**
+   * An object to map a templater key to a custom getter. The getter function
+   * should return a Promise that resolves to the correct string that the
+   * templater should replace the key with.
+   * @defaultValue `{}`
+   */
+  customGetters?: PresenceTemplaterGetters
 }
 
 export default PresenceManagerOptions;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,3 +3,5 @@ import Discord from 'discord.js';
 export type ConfigValue = string | boolean | null | number;
 
 export type CommandTrigger = Discord.Message | Discord.CommandInteraction;
+
+export type PresenceTemplaterGetters = Record<string, () => Promise<string>>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 import Discord from 'discord.js';
 
 export type ConfigValue = string | boolean | null | number;
+export type ConfigCustomValidators = Record<string, (value: ConfigValue) => void>;
 
 export type CommandTrigger = Discord.Message | Discord.CommandInteraction;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 import Discord from 'discord.js';
 
-export type ConfigValue = string | boolean | null | number;
+export type ConfigValue = string | boolean | null | number | string[] | boolean[] | number[];
 export type ConfigCustomValidators = Record<string, (value: ConfigValue) => void>;
 
 export type CommandTrigger = Discord.Message | Discord.CommandInteraction;

--- a/test/classes/command/CommandRegistry.spec.ts
+++ b/test/classes/command/CommandRegistry.spec.ts
@@ -182,12 +182,20 @@ describe('Classes: Command: CommandRegistry', () => {
     });
 
     describe('registerDefaultCommands()', () => {
-      it('should register all default commands.', () => {
+      it('should register all default regular commands if false is passed as parameter.', () => {
+        registry.registerDefaultGroups();
+        registry.registerDefaultCommands(false);
+
+        expect(registry.commands.get('help')).toBeInstanceOf(DefaultCommands.Regular.HelpRegularCommand);
+        expect(registry.commands.get('set_locale')).toBeInstanceOf(DefaultCommands.Regular.SetLocaleRegularCommand);
+      });
+
+      it('should register all default slash commands if true is passed as parameter.', () => {
         registry.registerDefaultGroups();
         registry.registerDefaultCommands();
 
-        expect(registry.commands.get('help')).toBeInstanceOf(DefaultCommands.HelpCommand);
-        expect(registry.commands.get('set_locale')).toBeInstanceOf(DefaultCommands.SetLocaleCommand);
+        expect(registry.commands.get('help')).toBeInstanceOf(DefaultCommands.Slash.HelpSlashCommand);
+        expect(registry.commands.get('set_locale')).toBeInstanceOf(DefaultCommands.Slash.SetLocaleSlashCommand);
       });
 
       it('should throw if the default groups are not registered prior.', () => {

--- a/test/classes/command/CommandRegistry.spec.ts
+++ b/test/classes/command/CommandRegistry.spec.ts
@@ -177,6 +177,7 @@ describe('Classes: Command: CommandRegistry', () => {
         registry.registerDefaultGroups();
 
         expect(registry.groups.get('misc')!.name).toBe('Miscellaneous Commands');
+        expect(registry.groups.get('config')!.name).toBe('Configuration Commands');
       });
     });
 
@@ -186,6 +187,7 @@ describe('Classes: Command: CommandRegistry', () => {
         registry.registerDefaultCommands();
 
         expect(registry.commands.get('help')).toBeInstanceOf(DefaultCommands.HelpCommand);
+        expect(registry.commands.get('set_locale')).toBeInstanceOf(DefaultCommands.SetLocaleCommand);
       });
 
       it('should throw if the default groups are not registered prior.', () => {

--- a/test/classes/command/default/SetLocaleCommand.spec.ts
+++ b/test/classes/command/default/SetLocaleCommand.spec.ts
@@ -1,0 +1,76 @@
+import Discord from 'discord.js';
+import SetLocaleCommand from '../../../../src/classes/command/default/SetLocaleCommand';
+import ExtendedClient from '../../../../src/classes/ExtendedClient';
+import GuildLocalizer from '../../../../src/classes/locale/GuildLocalizer';
+import { InteractionMock, GuildMock } from '../../../../__mocks__/discordMocks';
+import { mockedLocaleStrings } from '../../../../__mocks__/locale';
+
+describe('Classes: Command: Default: SetLocaleCommand', () => {
+  let command: SetLocaleCommand;
+
+  let clientMock: ExtendedClient;
+  let interactionMock: Discord.CommandInteraction;
+  let guildMock: Discord.Guild;
+  let guildLocalizerMock: GuildLocalizer;
+
+  beforeEach(() => {
+    clientMock = new ExtendedClient({ intents: [], localizer: { defaultLocale: 'en', localeStrings: mockedLocaleStrings } });
+    interactionMock = new InteractionMock() as unknown as Discord.CommandInteraction;
+
+    guildMock = new GuildMock() as Discord.Guild;
+    guildLocalizerMock = new GuildLocalizer(clientMock.localizer!, guildMock);
+
+    command = new SetLocaleCommand(clientMock);
+  });
+
+  describe('run()', () => {
+    it('should update the locale for that guild.', () => {
+      const getStringSpy = interactionMock.options.getString as jest.Mock;
+      getStringSpy.mockReturnValue('fr');
+      jest.spyOn(clientMock.localizer!, 'getLocalizer').mockReturnValue(guildLocalizerMock);
+
+      expect(guildLocalizerMock.locale).toBe('en');
+      return command.run(interactionMock)
+        .then(() => {
+          expect(guildLocalizerMock.locale).toBe('fr');
+        });
+    });
+
+    it('should not update the locale if the same one is already set.', () => {
+      const getStringSpy = interactionMock.options.getString as jest.Mock;
+      getStringSpy.mockReturnValue('en');
+      jest.spyOn(clientMock.localizer!, 'getLocalizer').mockReturnValue(guildLocalizerMock);
+
+      expect(guildLocalizerMock.locale).toBe('en');
+      return command.run(interactionMock)
+        .then(() => {
+          const updateSpy = jest.spyOn(guildLocalizerMock, 'updateLocale');
+          expect(updateSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    it('should reply if the new locale is the same as previous.', () => {
+      const getStringSpy = interactionMock.options.getString as jest.Mock;
+      getStringSpy.mockReturnValue('en');
+      jest.spyOn(clientMock.localizer!, 'getLocalizer').mockReturnValue(guildLocalizerMock);
+
+      return command.run(interactionMock)
+        .then(() => {
+          const replySpy = interactionMock.reply as jest.Mock;
+          expect(replySpy.mock.calls[0][0]).toContain('already set');
+        });
+    });
+
+    it('should reply that the locale has been updated.', () => {
+      const getStringSpy = interactionMock.options.getString as jest.Mock;
+      getStringSpy.mockReturnValue('fr');
+      jest.spyOn(clientMock.localizer!, 'getLocalizer').mockReturnValue(guildLocalizerMock);
+
+      return command.run(interactionMock)
+        .then(() => {
+          const replySpy = interactionMock.reply as jest.Mock;
+          expect(replySpy.mock.calls[0][0]).toContain('fr');
+        });
+    });
+  });
+});

--- a/test/classes/command/default/regular/HelpRegularCommand.spec.ts
+++ b/test/classes/command/default/regular/HelpRegularCommand.spec.ts
@@ -1,17 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import Discord from 'discord.js';
-import HelpCommand from '../../../../src/classes/command/default/HelpCommand';
-import ExtendedClient from '../../../../src/classes/ExtendedClient';
-import { MessageMock } from '../../../../__mocks__/discordMocks';
+import HelpRegularCommand from '../../../../../src/classes/command/default/regular/HelpRegularCommand';
+import ExtendedClient from '../../../../../src/classes/ExtendedClient';
+import { MessageMock } from '../../../../../__mocks__/discordMocks';
 
 const clientMock = new ExtendedClient({ prefix: '!', intents: [] });
 const messageMock = new MessageMock() as unknown as Discord.Message;
 
-describe('Classes: Command: Default: HelpCommand', () => {
-  let command: HelpCommand;
+describe('Classes: Command: Default: Regular: HelpRegularCommand', () => {
+  let command: HelpRegularCommand;
 
   beforeEach(() => {
-    command = new HelpCommand(clientMock);
+    command = new HelpRegularCommand(clientMock);
   });
 
   describe('prepareFields()', () => {

--- a/test/classes/command/default/regular/SetLocaleRegularCommand.spec.ts
+++ b/test/classes/command/default/regular/SetLocaleRegularCommand.spec.ts
@@ -1,0 +1,83 @@
+import Discord from 'discord.js';
+import SetLocaleRegularCommand from '../../../../../src/classes/command/default/regular/SetLocaleRegularCommand';
+import ExtendedClient from '../../../../../src/classes/ExtendedClient';
+import GuildLocalizer from '../../../../../src/classes/locale/GuildLocalizer';
+import { MessageMock, GuildMock } from '../../../../../__mocks__/discordMocks';
+import { mockedLocaleStrings } from '../../../../../__mocks__/locale';
+
+describe('Classes: Command: Default: Regular: SetLocaleRegularCommand', () => {
+  let command: SetLocaleRegularCommand;
+
+  let clientMock: ExtendedClient;
+  let messageMock: Discord.Message;
+  let guildMock: Discord.Guild;
+  let guildLocalizerMock: GuildLocalizer;
+
+  beforeEach(() => {
+    clientMock = new ExtendedClient({ prefix: '!', intents: [], localizer: { defaultLocale: 'en', localeStrings: mockedLocaleStrings } });
+    messageMock = new MessageMock() as unknown as Discord.Message;
+
+    guildMock = new GuildMock() as Discord.Guild;
+    guildLocalizerMock = new GuildLocalizer(clientMock.localizer!, guildMock);
+
+    command = new SetLocaleRegularCommand(clientMock);
+  });
+
+  describe('run()', () => {
+    it('should reply if no locale is supplied.', () => {
+      messageMock.content = '!set_locale';
+      jest.spyOn(clientMock.localizer!, 'getLocalizer').mockReturnValue(guildLocalizerMock);
+
+      return command.run(messageMock, [])
+        .then(() => {
+          const replySpy = messageMock.reply as jest.Mock;
+          expect(replySpy.mock.calls[0][0]).toContain('need to specify');
+        });
+    });
+
+    it('should update the locale for that guild.', () => {
+      messageMock.content = '!set_locale fr';
+      jest.spyOn(clientMock.localizer!, 'getLocalizer').mockReturnValue(guildLocalizerMock);
+
+      expect(guildLocalizerMock.locale).toBe('en');
+      return command.run(messageMock, ['fr'])
+        .then(() => {
+          expect(guildLocalizerMock.locale).toBe('fr');
+        });
+    });
+
+    it('should not update the locale if the same one is already set.', () => {
+      messageMock.content = '!set_locale en';
+      jest.spyOn(clientMock.localizer!, 'getLocalizer').mockReturnValue(guildLocalizerMock);
+
+      expect(guildLocalizerMock.locale).toBe('en');
+      return command.run(messageMock, ['en'])
+        .then(() => {
+          const updateSpy = jest.spyOn(guildLocalizerMock, 'updateLocale');
+          expect(updateSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    it('should reply if the new locale is the same as previous.', () => {
+      messageMock.content = '!set_locale en';
+      jest.spyOn(clientMock.localizer!, 'getLocalizer').mockReturnValue(guildLocalizerMock);
+
+      return command.run(messageMock, ['en'])
+        .then(() => {
+          const replySpy = messageMock.reply as jest.Mock;
+          expect(replySpy.mock.calls[0][0]).toContain('already set');
+        });
+    });
+
+    it('should reply that the locale has been updated.', () => {
+      messageMock.content = '!set_locale fr';
+      jest.spyOn(clientMock.localizer!, 'getLocalizer').mockReturnValue(guildLocalizerMock);
+
+      return command.run(messageMock, ['fr'])
+        .then(() => {
+          const replySpy = messageMock.reply as jest.Mock;
+          expect(replySpy.mock.calls[0][0]).toContain('fr');
+        });
+    });
+  });
+});

--- a/test/classes/command/default/slash/HelpSlashCommand.spec.ts
+++ b/test/classes/command/default/slash/HelpSlashCommand.spec.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import Discord from 'discord.js';
+import HelpSlashCommand from '../../../../../src/classes/command/default/slash/HelpSlashCommand';
+import ExtendedClient from '../../../../../src/classes/ExtendedClient';
+import { InteractionMock } from '../../../../../__mocks__/discordMocks';
+
+const clientMock = new ExtendedClient();
+const interactionMock = new InteractionMock() as unknown as Discord.CommandInteraction;
+
+describe('Classes: Command: Default: Slash: HelpSlashCommand', () => {
+  let command: HelpSlashCommand;
+
+  beforeEach(() => {
+    command = new HelpSlashCommand(clientMock);
+  });
+
+  describe('prepareFields()', () => {
+    it('should return an array of objects with the commands information by group.', () => {
+      clientMock.registry.registerGroup('misc', 'Misc');
+      clientMock.registry.registerCommand(command);
+
+      const result = command.prepareFields();
+
+      expect(result).toEqual([{
+        title: 'Misc',
+        text: `${command.emoji} **/${command.name}** - ${command.description}\n`
+      }]);
+    });
+  });
+
+  describe('run()', () => {
+    it('should send an embed.', () => {
+      const sendSpy = interactionMock.reply as jest.Mock;
+
+      return command.run(interactionMock)
+        .then(() => {
+          expect(sendSpy).toHaveBeenCalledTimes(1);
+          expect(sendSpy.mock.calls[0][0].embeds[0]).toBeInstanceOf(Discord.MessageEmbed);
+        });
+    });
+  });
+});

--- a/test/classes/command/default/slash/SetLocaleSlashCommand.spec.ts
+++ b/test/classes/command/default/slash/SetLocaleSlashCommand.spec.ts
@@ -1,12 +1,12 @@
 import Discord from 'discord.js';
-import SetLocaleCommand from '../../../../src/classes/command/default/SetLocaleCommand';
-import ExtendedClient from '../../../../src/classes/ExtendedClient';
-import GuildLocalizer from '../../../../src/classes/locale/GuildLocalizer';
-import { InteractionMock, GuildMock } from '../../../../__mocks__/discordMocks';
-import { mockedLocaleStrings } from '../../../../__mocks__/locale';
+import SetLocaleSlashCommand from '../../../../../src/classes/command/default/slash/SetLocaleSlashCommand';
+import ExtendedClient from '../../../../../src/classes/ExtendedClient';
+import GuildLocalizer from '../../../../../src/classes/locale/GuildLocalizer';
+import { InteractionMock, GuildMock } from '../../../../../__mocks__/discordMocks';
+import { mockedLocaleStrings } from '../../../../../__mocks__/locale';
 
-describe('Classes: Command: Default: SetLocaleCommand', () => {
-  let command: SetLocaleCommand;
+describe('Classes: Command: Default: Slash: SetLocaleSlashCommand', () => {
+  let command: SetLocaleSlashCommand;
 
   let clientMock: ExtendedClient;
   let interactionMock: Discord.CommandInteraction;
@@ -20,7 +20,7 @@ describe('Classes: Command: Default: SetLocaleCommand', () => {
     guildMock = new GuildMock() as Discord.Guild;
     guildLocalizerMock = new GuildLocalizer(clientMock.localizer!, guildMock);
 
-    command = new SetLocaleCommand(clientMock);
+    command = new SetLocaleSlashCommand(clientMock);
   });
 
   describe('run()', () => {

--- a/test/classes/config/ConfigValidator.spec.ts
+++ b/test/classes/config/ConfigValidator.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import ConfigValidator from '../../../src/classes/config/ConfigValidator';
 
 const mockedConfig = {
@@ -5,7 +6,11 @@ const mockedConfig = {
   NUM: 123,
   F: false,
   F_STRING: 'false',
-  NULLABLE: 'optional'
+  NULLABLE: 'optional',
+  STR_ARRAY: ['hi', 'there'],
+  BOOL_ARRAY: [true, false],
+  NUM_ARRAY: [3.14, 42],
+  STR_MUL_SINGLE: ['string here']
 };
 
 const mockedTypes = {
@@ -13,7 +18,11 @@ const mockedTypes = {
   NUM: 'number',
   F: 'boolean',
   F_STRING: ['string', 'boolean'],
-  NULLABLE: ['string', 'null']
+  NULLABLE: ['string', 'null'],
+  STR_ARRAY: 'string[]',
+  BOOL_ARRAY: 'boolean[]',
+  NUM_ARRAY: 'number[]',
+  STR_MUL_SINGLE: ['string', 'string[]']
 };
 
 describe('Classes: Config: ConfigValidator', () => {
@@ -132,19 +141,113 @@ describe('Classes: Config: ConfigValidator', () => {
         expect(casted.S).toBe('123');
       });
 
-      it('should keep the value as a string if type contains string.', () => {
-        const validator = new ConfigValidator({ S: ['number', 'string'] });
+      it('should cast to null if the value is null and the type contains string and null.', () => {
+        const validator1 = new ConfigValidator({ N: ['string', 'null'] });
+        const validator2 = new ConfigValidator({ N: ['null', 'string'] });
 
-        const casted = validator.castFromString({ S: '123' });
-        expect(typeof casted.S).toBe('string');
-        expect(casted.S).toBe('123');
+        const casted1 = validator1.castFromString({ N: 'null' });
+        const casted2 = validator2.castFromString({ N: 'null' });
+
+        expect(casted1.N).toBeNull();
+        expect(casted2.N).toBeNull();
       });
 
-      it('should cast to null if the value is null and the type contains string and null.', () => {
-        const validator = new ConfigValidator({ N: ['string', 'null'] });
+      it('should cast to boolean if it is a valid boolean string and the type contains boolean.', () => {
+        const validator1 = new ConfigValidator({ B: ['string', 'boolean'] });
+        const validator2 = new ConfigValidator({ B: ['boolean', 'string'] });
 
-        const casted = validator.castFromString({ N: 'null' });
-        expect(casted.N).toBeNull();
+        const casted1 = validator1.castFromString({ B: 'true' });
+        const casted2 = validator2.castFromString({ B: 'false' });
+
+        expect(casted1.B).toBe(true);
+        expect(casted2.B).toBe(false);
+      });
+
+      it('should return the value if it is an invalid boolean string and the type contains boolean.', () => {
+        const validator1 = new ConfigValidator({ B: ['string', 'boolean'] });
+        const validator2 = new ConfigValidator({ B: ['boolean', 'string'] });
+
+        const casted1 = validator1.castFromString({ B: 'truthy' });
+        const casted2 = validator2.castFromString({ B: 'truthy' });
+
+        expect(casted1.B).toBe('truthy');
+        expect(casted2.B).toBe('truthy');
+      });
+
+      it('should return the value if it is an invalid number string and the type contains number.', () => {
+        const validator1 = new ConfigValidator({ N: ['string', 'number'] });
+        const validator2 = new ConfigValidator({ N: ['number', 'string'] });
+
+        const casted1 = validator1.castFromString({ N: '123.213.21' });
+        const casted2 = validator2.castFromString({ N: '123.213.21' });
+
+        expect(casted1.N).toBe('123.213.21');
+        expect(casted2.N).toBe('123.213.21');
+      });
+
+      it('should cast to number if it is a valid number string and the type contains number.', () => {
+        const validator1 = new ConfigValidator({ N: ['string', 'number'] });
+        const validator2 = new ConfigValidator({ N: ['number', 'string'] });
+
+        const casted1 = validator1.castFromString({ N: '3.14' });
+        const casted2 = validator2.castFromString({ N: '42' });
+
+        expect(casted1.N).toBe(3.14);
+        expect(casted2.N).toBe(42);
+      });
+
+      it('should return the value if it is an invalid number[] string and the type contains number[].', () => {
+        const validator1 = new ConfigValidator({ N: ['string', 'number[]'] });
+        const validator2 = new ConfigValidator({ N: ['number[]', 'string'] });
+
+        const casted1 = validator1.castFromString({ N: '123.213.21,23,23' });
+        const casted2 = validator2.castFromString({ N: '123.213.21,23,23' });
+
+        expect(casted1.N).toBe('123.213.21,23,23');
+        expect(casted2.N).toBe('123.213.21,23,23');
+      });
+
+      it('should cast to number[] if it is a valid number[] string and the type contains number[].', () => {
+        const validator1 = new ConfigValidator({ N: ['string', 'number[]'] });
+        const validator2 = new ConfigValidator({ N: ['number[]', 'string'] });
+
+        const casted1 = validator1.castFromString({ N: '3.14,42,1' });
+        const casted2 = validator2.castFromString({ N: '3.14,42,1' });
+
+        expect(casted1.N as number[]).toStrictEqual([3.14, 42, 1]);
+        expect(casted2.N as number[]).toStrictEqual([3.14, 42, 1]);
+      });
+
+      it('should return the value if it is an invalid boolean[] string and the type contains boolean[].', () => {
+        const validator1 = new ConfigValidator({ B: ['string', 'boolean[]'] });
+        const validator2 = new ConfigValidator({ B: ['boolean[]', 'string'] });
+
+        const casted1 = validator1.castFromString({ B: 'true,false,truthy' });
+        const casted2 = validator2.castFromString({ B: 'true,false,truthy' });
+
+        expect(casted1.B).toBe('true,false,truthy');
+        expect(casted2.B).toBe('true,false,truthy');
+      });
+
+      it('should cast to boolean[] if it is a valid boolean[] string and the type contains boolean[].', () => {
+        const validator1 = new ConfigValidator({ B: ['string', 'boolean[]'] });
+        const validator2 = new ConfigValidator({ B: ['boolean[]', 'string'] });
+
+        const casted1 = validator1.castFromString({ B: 'true,false,true' });
+        const casted2 = validator2.castFromString({ B: 'true,false,true' });
+
+        expect(casted1.B as boolean[]).toStrictEqual([true, false, true]);
+        expect(casted2.B as boolean[]).toStrictEqual([true, false, true]);
+      });
+    });
+
+    describe('With "string[]"', () => {
+      it('should cast every item into a string.', () => {
+        const validator = new ConfigValidator({ S: 'string[]' });
+
+        const casted = validator.castFromString({ S: 'one,two,three' });
+
+        expect(casted.S).toStrictEqual(['one', 'two', 'three']);
       });
     });
 
@@ -159,12 +262,12 @@ describe('Classes: Config: ConfigValidator', () => {
         expect(casted.F).toBe(false);
       });
 
-      it('should keep it as a string if it is not a valid boolean string.', () => {
+      it('should throw if it is not a valid boolean string.', () => {
         const validator = new ConfigValidator({ B: 'boolean' });
 
-        const casted = validator.castFromString({ B: 'truthy' });
-        expect(typeof casted.B).toBe('string');
-        expect(casted.B).toBe('truthy');
+        expect(() => {
+          validator.castFromString({ B: 'truthy' });
+        }).toThrow();
       });
 
       it('should cast the value to a boolean if the type contains boolean and it is a valid boolean string.', () => {
@@ -180,17 +283,35 @@ describe('Classes: Config: ConfigValidator', () => {
         expect(casted2.B).toBe(true);
       });
 
-      it('should not cast the value to a boolean if the type contains boolean and it is not a valid boolean string.', () => {
+      it('should throw if the type contains boolean and it is not a valid boolean string.', () => {
         const validator1 = new ConfigValidator({ B: ['boolean', 'number'] });
         const validator2 = new ConfigValidator({ B: ['number', 'boolean'] });
 
-        const casted1 = validator1.castFromString({ B: 'truthy' });
-        expect(typeof casted1.B).toBe('string');
-        expect(casted1.B).toBe('truthy');
+        expect(() => {
+          validator1.castFromString({ B: 'truthy' });
+        }).toThrow();
 
-        const casted2 = validator2.castFromString({ B: 'truthy' });
-        expect(typeof casted2.B).toBe('string');
-        expect(casted2.B).toBe('truthy');
+        expect(() => {
+          validator2.castFromString({ B: 'truthy' });
+        }).toThrow();
+      });
+    });
+
+    describe('With "boolean[]"', () => {
+      it('should cast every item into a boolean.', () => {
+        const validator = new ConfigValidator({ B: 'boolean[]' });
+
+        const casted = validator.castFromString({ B: 'true,false,true' });
+
+        expect(casted.B).toStrictEqual([true, false, true]);
+      });
+
+      it('should throw if any of the items is not a valid boolean string.', () => {
+        const validator = new ConfigValidator({ B: 'boolean[]' });
+
+        expect(() => {
+          validator.castFromString({ B: 'true,false,truthy' });
+        }).toThrow();
       });
     });
 
@@ -205,12 +326,12 @@ describe('Classes: Config: ConfigValidator', () => {
         expect(casted.F).toBe(3.1415);
       });
 
-      it('should keep it as a string if it is not a valid number string.', () => {
+      it('should throw if it is not a valid number string.', () => {
         const validator = new ConfigValidator({ N: 'number' });
 
-        const casted = validator.castFromString({ N: 'not-a-number' });
-        expect(typeof casted.N).toBe('string');
-        expect(casted.N).toBe('not-a-number');
+        expect(() => {
+          validator.castFromString({ N: 'not-a-number' });
+        }).toThrow();
       });
 
       it('should cast the value to a number if the type contains number and it is a valid number string.', () => {
@@ -226,17 +347,35 @@ describe('Classes: Config: ConfigValidator', () => {
         expect(casted2.N).toBe(42);
       });
 
-      it('should not cast the value to a number if the type contains number and it is not a valid number string.', () => {
+      it('should throw if the type contains number and it is not a valid number string.', () => {
         const validator1 = new ConfigValidator({ N: ['boolean', 'number'] });
         const validator2 = new ConfigValidator({ N: ['number', 'boolean'] });
 
-        const casted1 = validator1.castFromString({ N: 'not-a-number' });
-        expect(typeof casted1.N).toBe('string');
-        expect(casted1.N).toBe('not-a-number');
+        expect(() => {
+          validator1.castFromString({ N: 'not-a-number' });
+        }).toThrow();
 
-        const casted2 = validator2.castFromString({ N: 'not-a-number' });
-        expect(typeof casted2.N).toBe('string');
-        expect(casted2.N).toBe('not-a-number');
+        expect(() => {
+          validator2.castFromString({ N: 'not-a-number' });
+        }).toThrow();
+      });
+    });
+
+    describe('With "number[]"', () => {
+      it('should cast every item into a number.', () => {
+        const validator = new ConfigValidator({ N: 'number[]' });
+
+        const casted = validator.castFromString({ N: '1,2,3' });
+
+        expect(casted.N).toStrictEqual([1, 2, 3]);
+      });
+
+      it('should throw if any of the items is not a valid number string.', () => {
+        const validator = new ConfigValidator({ N: 'number[]' });
+
+        expect(() => {
+          validator.castFromString({ N: '123,223,11.123.1213' });
+        }).toThrow();
       });
     });
 
@@ -248,12 +387,12 @@ describe('Classes: Config: ConfigValidator', () => {
         expect(casted.N).toBeNull();
       });
 
-      it('should keep it as a string if it is not a valid null string.', () => {
+      it('should throw if it is not a valid null string.', () => {
         const validator = new ConfigValidator({ N: 'null' });
 
-        const casted = validator.castFromString({ N: 'not-null' });
-        expect(typeof casted.N).toBe('string');
-        expect(casted.N).toBe('not-null');
+        expect(() => {
+          validator.castFromString({ N: 'not-null' });
+        }).toThrow();
       });
 
       it('should cast the value to a null if the type contains null and it is a valid null string.', () => {
@@ -267,17 +406,17 @@ describe('Classes: Config: ConfigValidator', () => {
         expect(casted2.N).toBeNull();
       });
 
-      it('should not cast the value to a null if the type contains null and it is not a valid null string.', () => {
+      it('should throw if the type contains null and it is not a valid null string.', () => {
         const validator1 = new ConfigValidator({ N: ['null', 'number'] });
         const validator2 = new ConfigValidator({ N: ['number', 'null'] });
 
-        const casted1 = validator1.castFromString({ N: 'not-null' });
-        expect(typeof casted1.N).toBe('string');
-        expect(casted1.N).toBe('not-null');
+        expect(() => {
+          validator1.castFromString({ N: 'not-null' });
+        }).toThrow();
 
-        const casted2 = validator2.castFromString({ N: 'not-null' });
-        expect(typeof casted2.N).toBe('string');
-        expect(casted2.N).toBe('not-null');
+        expect(() => {
+          validator2.castFromString({ N: 'not-null' });
+        }).toThrow();
       });
     });
   });

--- a/test/classes/config/ConfigValidator.spec.ts
+++ b/test/classes/config/ConfigValidator.spec.ts
@@ -82,6 +82,34 @@ describe('Classes: Config: ConfigValidator', () => {
         validator.validate({ NULLABLE: null });
       }).not.toThrow();
     });
+
+    it('should throw if value does not conform custom validator.', () => {
+      validator = new ConfigValidator({ CUSTOM: 'string' }, {
+        CUSTOM: (value) => {
+          if (value !== 'my_enum') {
+            throw new TypeError('Invalid value for key CUSTOM');
+          }
+        }
+      });
+
+      expect(() => {
+        validator.validate({ CUSTOM: 'invalid' });
+      }).toThrow(TypeError);
+    });
+
+    it('should not throw if value does conform custom validator.', () => {
+      validator = new ConfigValidator({ CUSTOM: 'string' }, {
+        CUSTOM: (value) => {
+          if (value !== 'my_enum') {
+            throw new TypeError('Invalid value for key CUSTOM');
+          }
+        }
+      });
+
+      expect(() => {
+        validator.validate({ CUSTOM: 'my_enum' });
+      }).not.toThrow(TypeError);
+    });
   });
 
   describe('castFromString()', () => {

--- a/test/classes/locale/GuildLocalizer.spec.ts
+++ b/test/classes/locale/GuildLocalizer.spec.ts
@@ -1,0 +1,120 @@
+import Discord from 'discord.js';
+import GuildLocalizer from '../../../src/classes/locale/GuildLocalizer';
+import Localizer from '../../../src/classes/locale/Localizer';
+import ExtendedClient from '../../../src/classes/ExtendedClient';
+import { GuildMock } from '../../../__mocks__/discordMocks';
+import ConcreteDataProvider from '../../../__mocks__/dataProvider';
+import { mockedLocaleStrings } from '../../../__mocks__/locale';
+
+const clientMock = new ExtendedClient();
+const mainLocalizerMock = new Localizer(clientMock, { defaultLocale: 'en', localeStrings: mockedLocaleStrings });
+const guildMock = new GuildMock() as Discord.Guild;
+
+describe('Classes: Locale: GuildLocalizer', () => {
+  let localizer: GuildLocalizer;
+
+  let getSpy: jest.SpyInstance;
+  let setSpy: jest.SpyInstance;
+
+  beforeAll(async() => {
+    await clientMock.setDataProvider(new ConcreteDataProvider(clientMock));
+    getSpy = jest.spyOn(clientMock.dataProvider!, 'get');
+    setSpy = jest.spyOn(clientMock.dataProvider!, 'set');
+  });
+
+  beforeEach(() => {
+    localizer = new GuildLocalizer(mainLocalizerMock, guildMock);
+  });
+
+  describe('init()', () => {
+    it('should resolve the default locale if no data provider is present in client.', () => {
+      const client = new ExtendedClient();
+      const mainLocalizer = new Localizer(client, { defaultLocale: 'en', localeStrings: mockedLocaleStrings });
+      const guildLocalizer = new GuildLocalizer(mainLocalizer, guildMock);
+
+      return guildLocalizer.init()
+        .then((locale) => {
+          expect(locale).toBe('en');
+        });
+    });
+
+    it('should reject if the locale stored is not supported.', () => {
+      getSpy.mockResolvedValueOnce('unknown');
+      expect.assertions(2);
+
+      return localizer.init()
+        .catch((error) => {
+          expect(error).toBeInstanceOf(Error);
+          expect(localizer.locale).toBe('en');
+        });
+    });
+
+    it('should resolve the locale stored in the data provider.', () => {
+      getSpy.mockResolvedValueOnce('fr');
+
+      return localizer.init()
+        .then((locale) => {
+          expect(locale).toBe('fr');
+        });
+    });
+
+    it('should set the locale value.', () => {
+      getSpy.mockResolvedValueOnce('fr');
+
+      return localizer.init()
+        .then(() => {
+          expect(localizer.locale).toBe('fr');
+        });
+    });
+  });
+
+  describe('updateLocale()', () => {
+    it('should reject if the supplied locale is not supported.', () => {
+      expect.assertions(1);
+
+      return localizer.updateLocale('unknown')
+        .catch((error) => {
+          expect(error.message).toContain('not a supported locale');
+        });
+    });
+
+    it('should not update the locale if the supplied one is not supported.', () => {
+      expect.assertions(1);
+
+      return localizer.updateLocale('unknown')
+        .catch(() => {
+          expect(localizer.locale).toBe('en');
+        });
+    });
+
+    it('should set the locale value with the one supplied.', () => {
+      return localizer.updateLocale('es')
+        .then(() => {
+          expect(localizer.locale).toBe('es');
+        });
+    });
+
+    it('should update the locale in the data provider.', () => {
+      return localizer.updateLocale('es')
+        .then(() => {
+          expect(setSpy).toHaveBeenCalledWith(localizer.guild, 'locale', 'es');
+        });
+    });
+  });
+
+  describe('translate()', () => {
+    it('should call localizer.translate with the correct values.', () => {
+      const translateSpy = jest.spyOn(localizer.localizer, 'translate');
+      localizer.translate('message.test.hello');
+      expect(translateSpy).toHaveBeenCalledWith('message.test.hello', localizer.locale, {});
+    });
+  });
+
+  describe('t()', () => {
+    it('should call translate with the correct values.', () => {
+      const translateSpy = jest.spyOn(localizer, 'translate');
+      localizer.t('message.test.hello');
+      expect(translateSpy).toHaveBeenCalledWith('message.test.hello', {});
+    });
+  });
+});

--- a/test/classes/locale/Localizer.spec.ts
+++ b/test/classes/locale/Localizer.spec.ts
@@ -1,0 +1,123 @@
+import Discord from 'discord.js';
+import Localizer from '../../../src/classes/locale/Localizer';
+import GuildLocalizer from '../../../src/classes/locale/GuildLocalizer';
+import ExtendedClient from '../../../src/classes/ExtendedClient';
+import { mockedLocaleStrings } from '../../../__mocks__/locale';
+import { GuildMock } from '../../../__mocks__/discordMocks';
+
+jest.mock('discord.js');
+
+const clientMock = new ExtendedClient();
+const guildMock = new GuildMock() as Discord.Guild;
+
+describe('Classes: Locale: Localizer', () => {
+  let localizer: Localizer;
+
+  beforeEach(() => {
+    localizer = new Localizer(clientMock, { defaultLocale: 'en', localeStrings: mockedLocaleStrings });
+  });
+
+  describe('constructor()', () => {
+    it('should throw if the default locale is not supported.', () => {
+      expect(() => {
+        localizer = new Localizer(clientMock, { defaultLocale: 'unknown', localeStrings: mockedLocaleStrings });
+      }).toThrow();
+    });
+  });
+
+  describe('init()', () => {
+    it('should populate guildLocalizers with their respective localizers.', () => {
+      return localizer.init()
+        .then(() => {
+          expect(localizer.guildLocalizers.size).toBe(3);
+          expect(localizer.guildLocalizers.each((l) => l instanceof GuildLocalizer));
+        });
+    });
+
+    it('should resolve the locales of each guild localizer.', () => {
+      return localizer.init()
+        .then((locales) => {
+          expect(locales).toStrictEqual(['en', 'en', 'en']);
+        });
+    });
+  });
+
+  describe('getLocalizer()', () => {
+    it("should return the specified guild's localizer.", () => {
+      const guildLocalizer = new GuildLocalizer(localizer, guildMock);
+      localizer.guildLocalizers.set(guildMock.id, guildLocalizer);
+
+      expect(localizer.getLocalizer(guildMock)).toBe(guildLocalizer);
+    });
+  });
+
+  describe('getAvailableLocales()', () => {
+    it('should return the available locales.', () => {
+      const locales = localizer.getAvailableLocales();
+      expect(locales).toContain('en');
+      expect(locales).toContain('es');
+      expect(locales).toContain('fr');
+    });
+  });
+
+  describe('isLocaleSupported()', () => {
+    it('should return true if the locale is supported.', () => {
+      expect(localizer.isLocaleSupported('en')).toBe(true);
+    });
+
+    it('should return false if the locale is not supported.', () => {
+      expect(localizer.isLocaleSupported('unknown')).toBe(false);
+    });
+  });
+
+  describe('translate()', () => {
+    it('should throw if given an invalid locale.', () => {
+      expect(() => {
+        localizer.translate('message.test.hello', 'unknown');
+      }).toThrow();
+    });
+
+    it('should throw if given an invalid message key.', () => {
+      expect(() => {
+        localizer.translate('unknown', 'en');
+      }).toThrow();
+    });
+
+    it('should return the message string translated.', () => {
+      const english = localizer.translate('message.test.hello', 'en');
+      const spanish = localizer.translate('message.test.hello', 'es');
+      const french = localizer.translate('message.test.hello', 'fr');
+
+      expect(english).toBe('Hello');
+      expect(spanish).toBe('Hola');
+      expect(french).toBe('Bonjour');
+    });
+
+    it('should use the default locale if no locale is given.', () => {
+      const translated1 = localizer.translate('message.test.bye');
+      const translated2 = localizer.translate('message.test.bye', null);
+
+      expect(translated1).toBe('Bye');
+      expect(translated2).toBe('Bye');
+    });
+
+    it('should return the message string translated with values applied.', () => {
+      const name = 'moonstar';
+      const english = localizer.translate('message.test.with_value', 'en', { name });
+      const spanish = localizer.translate('message.test.with_value', 'es', { name });
+      const french = localizer.translate('message.test.with_value', 'fr', { name });
+
+      expect(english).toBe('Hello moonstar!');
+      expect(spanish).toBe('Hola moonstar!');
+      expect(french).toBe('Bonjour moonstar!');
+    });
+  });
+
+  describe('t()', () => {
+    it('should call translate with the correct values.', () => {
+      const translateSpy = jest.spyOn(localizer, 'translate');
+      localizer.t('message.test.hello', 'en');
+      expect(translateSpy).toHaveBeenCalledWith('message.test.hello', 'en', {});
+    });
+  });
+});

--- a/test/classes/presence/PresenceTemplater.spec.ts
+++ b/test/classes/presence/PresenceTemplater.spec.ts
@@ -21,7 +21,7 @@ describe('Classes: Presence: PresenceTemplater', () => {
 
   beforeEach(() => {
     clientMock = new ExtendedClient({ prefix: '?', owner: '123', intents: [] });
-    templater = new PresenceTemplater(clientMock);
+    templater = new PresenceTemplater(clientMock, {});
 
     for (let i = 0; i < 3; i++) {
       const command = new ConcreteRegularCommand(clientMock, { name: Math.random().toString() });
@@ -39,11 +39,25 @@ describe('Classes: Presence: PresenceTemplater', () => {
         });
     });
 
-    it('should return the string for key: num_guilds.', async() => {
+    it('should resolve the string for custom key.', async() => {
+      const outScopeObj = {
+        key: 'whatever'
+      };
+
+      templater = new PresenceTemplater(clientMock, {
+        custom: async() => 'custom_value',
+        customOuter: async() => outScopeObj.key
+      });
+
+      expect(await templater.get('custom')).toBe('custom_value');
+      expect(await templater.get('customOuter')).toBe('whatever');
+    });
+
+    it('should resolve the string for key: num_guilds.', async() => {
       expect(await templater.get('num_guilds')).toBe('3');
     });
 
-    it('should return the string for key: num_guilds for a sharded client.', async() => {
+    it('should resolve the string for key: num_guilds for a sharded client.', async() => {
       clientMock.shard = new ShardClientUtilMock() as unknown as Discord.ShardClientUtil;
       const fetchMock = clientMock.shard.fetchClientValues as jest.Mock;
       fetchMock.mockResolvedValue([3, 3, 1]);
@@ -51,35 +65,35 @@ describe('Classes: Presence: PresenceTemplater', () => {
       expect(await templater.get('num_guilds')).toBe('7');
     });
 
-    it('should return the string for key: prefix.', async() => {
+    it('should resolve the string for key: prefix.', async() => {
       expect(await templater.get('prefix')).toBe('?');
     });
 
-    it('should return the string for key: cur_time.', async() => {
+    it('should resolve the string for key: cur_time.', async() => {
       expect(await templater.get('cur_time')).toBe('12:24:32 AM');
     });
 
-    it('should return the string for key: owner_name.', async() => {
+    it('should resolve the string for key: owner_name.', async() => {
       expect(await templater.get('owner_name')).toBe('owner');
     });
 
-    it('should return the string for key: client_name.', async() => {
+    it('should resolve the string for key: client_name.', async() => {
       expect(await templater.get('client_name')).toBe('client');
     });
 
-    it('should return the string for key: uptime.', async() => {
+    it('should resolve the string for key: uptime.', async() => {
       expect(await templater.get('uptime')).toBe('177 days, 13 hours and 27 minutes');
     });
 
-    it('should return the string for key: ready_time.', async() => {
+    it('should resolve the string for key: ready_time.', async() => {
       expect(await templater.get('ready_time')).toBe('Mon, 14/08/71 @05:08:AM');
     });
 
-    it('should return the string for key: num_members.', async() => {
+    it('should resolve the string for key: num_members.', async() => {
       expect(await templater.get('num_members')).toBe('17');
     });
 
-    it('should return the string for key: num_members for a sharded client.', async() => {
+    it('should resolve the string for key: num_members for a sharded client.', async() => {
       clientMock.shard = new ShardClientUtilMock() as unknown as Discord.ShardClientUtil;
       const fetchMock = clientMock.shard.fetchClientValues as jest.Mock;
       fetchMock.mockResolvedValue([clientMock.guilds.cache, clientMock.guilds.cache, clientMock.guilds.cache]);
@@ -88,7 +102,7 @@ describe('Classes: Presence: PresenceTemplater', () => {
       expect(await templater.get('num_members')).toBe(expected.toString());
     });
 
-    it('should return the string for key: num_commands.', async() => {
+    it('should resolve the string for key: num_commands.', async() => {
       expect(await templater.get('num_commands')).toBe('3');
     });
   });


### PR DESCRIPTION
### :page_facing_up: Description

This PR corresponds to the version 2.1.0 of the package, it includes the following changes:

- Added support for custom getters for `PresenteTemplater`. You can define a `customGetters` object inside of `clientOptions.presence` to map a custom key to a getter.
- Added support for custom validators for `ConfigProvider`. You can define a `customValidators` object inside of `configProviderOptions` to map a config key to a validator function. This validator function should throw a `TypeError` if the value provided is not valid according to your own criteria.
- Added support for array config values. You can use types `string[]`, `boolean[]` and `number[]`.
- Changed the behaviour of type casting for types that contain `string`. Before, if a type contained `string`, the value would be kept as a string. Now, the value will be cast to whatever other type is specified and remain as a string if the casting process failed.
- Now, if a casting fails (if a value is passed through environment variables that do not conform to the type specified), the `ConfigProvider` constructor will throw.
- Added a Localizer class to help with bot localization. To use this, simply pass a `localizer` object in the client's options and specify the translated messages in `localizer.localeStrings`. The localizer contains the context for each guild what locale it should use. It also supports persistence if a data provider is added to the client.
- Added a default SetLocaleCommand that updates the locale for the guild the command was issued from.
- Added regular and slash versions of HelpCommand and SetLocaleCommand.
- Changed how the default commands are registered. Pass `false` to `client.registry.registerDefaultCommands` to register the regular commands instead of the slash ones. Slash commands are registered by default if nothing is passed as parameter.