### PR TITLE
Bugfix/config localizer redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ client.on('ready', async() => {
 ### Localizing Your Bot
 
 The package contains a [Localizer](https://docs.greencoaststudios.com/discord.js-extended/master/classes/discord_js_extended.localizer.html) class to help with the localization of your bot. In order to use it, you should pass a `localizer` object to your `client` constructor and
-initialize the localizer in the `ready` event.
+initialize the localizer in the `ready` event. Keep in mind that you absolutely need the `GUILDS` intent in your client for this to work properly.
 
 ```js
 const client = new ExtendedClient({
@@ -211,7 +211,8 @@ const client = new ExtendedClient({
     defaultLocale: 'en', // The default locale for your bot.
     dataProviderKey: 'locale', // The key to be used to store the locale for each guild in the client's data provider.
     localeStrings: locales
-  }
+  },
+  intents: ['GUILDS']
 });
 
 client.on('ready', async() => {
@@ -244,6 +245,8 @@ const locales = {
 ```
 
 Locale messages should follow the [ICU format](https://formatjs.io/docs/intl-messageformat/#common-usage-example).
+
+In case a message is not available in a certain locale and it is requested, the message from the default locale will be picked.
 
 Inside a command, you may use the localizer in the following manner:
 
@@ -354,7 +357,7 @@ module.exports = class MyCommand extends SlashCommand {
       ownerOnly: false, // Whether the command may only be used by the owner. Defaults to false.
       userPermissions: Permissions.FLAGS.MANAGE_CHANNELS, // The PermissionResolvable representing the permissions that users require to execute this command. Defaults to null.
       ownerOverride: true, // Whether the owner may execute this command even if they don't have the required permissions. Defaults to true.
-      dataBuilder: new SlashCommandBuilder()
+      dataBuilder: new SlashCommandBuilder() // You do not need to use .setName() and .setDescription(), they're handled internally with the data above.
     });
 
     run(interaction) {
@@ -384,6 +387,7 @@ client options and have the following `ready` event handler.
 
 ```js
 client.on('ready', async() => {
+  client.deployer.rest.setToken(config.get('TOKEN'));
   await client.deployer.deployToTestingGuild();
 });
 ```
@@ -423,6 +427,7 @@ client.registry
 
 client.on('ready', async() => {
   try {
+    client.deployer.rest.setToken(config.get('TOKEN'));
     await client.deployer.deployGlobally();
   } catch (error) {
     console.error('Something happened!', error);

--- a/__mocks__/locale.ts
+++ b/__mocks__/locale.ts
@@ -2,7 +2,8 @@ export const mockedLocaleStrings = {
   en: {
     'message.test.hello': 'Hello',
     'message.test.bye': 'Bye',
-    'message.test.with_value': 'Hello {name}!'
+    'message.test.with_value': 'Hello {name}!',
+    'exists.only.in.en': 'I only exist in english'
   },
   es: {
     'message.test.hello': 'Hola',

--- a/example/command-deploy.js
+++ b/example/command-deploy.js
@@ -25,6 +25,7 @@ client.registry
 
 client.on('ready', async() => {
   try {
+    client.deployer.rest.setToken(config.get('TOKEN'));
     await client.deployer.deployGlobally();
   } catch (error) {
     console.error('Something happened!', error);

--- a/example/commands/slash/LocalizedSlashCommand.js
+++ b/example/commands/slash/LocalizedSlashCommand.js
@@ -14,7 +14,7 @@ class LocalizedSlashCommand extends SlashCommand {
   run(interaction) {
     const localizer = this.client.localizer.getLocalizer(interaction.guild);
 
-    return interaction.reply(localizer.t('greetings.hello', { name: interaction.user.username }));
+    return interaction.reply(localizer.t('extra.only_english', { name: interaction.user.username }));
   }
 }
 

--- a/example/index.js
+++ b/example/index.js
@@ -1,7 +1,6 @@
 require('dotenv').config();
 const path = require('path');
 const logger = require('@greencoast/logger');
-const { Intents } = require('discord.js');
 const { ExtendedClient, ConfigProvider } = require('@greencoast/discord.js-extended');
 const RedisDataProvider = require('@greencoast/discord.js-extended/dist/providers/RedisDataProvider').default;
 const locales = require('./locale');
@@ -48,7 +47,7 @@ const client = new ExtendedClient({
   },
   config,
   errorOwnerReporting: true,
-  intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.DIRECT_MESSAGES],
+  intents: ['GUILDS', 'GUILD_MESSAGES'],
   testingGuildID: '756628171494916098',
   localizer: {
     defaultLocale: 'en',
@@ -76,9 +75,11 @@ client.on('ready', async() => {
 
   await client.setDataProvider(dataProvider); // It would be recommended to set the data provider once the client is ready.
   await client.localizer.init(); // Initialize the localizer after setting up the data provider.
+
+  client.deployer.rest.setToken(config.get('TOKEN'));
   await client.deployer.deployToTestingGuild(); // Deploy slash commands to the testing guild.
 
   logger.info(`My numbers from the environment variable are: ${client.config.get('MY_NUM_ARRAY').join(', ')}`);
 });
 
-client.login(client.config.get('TOKEN'));
+client.login(config.get('TOKEN'));

--- a/example/locale/en.js
+++ b/example/locale/en.js
@@ -6,7 +6,8 @@ const GREETINGS = {
 };
 
 const EXTRA = {
-  'extra.nice_weather': "It's {temperature}, it's a nice weather!"
+  'extra.nice_weather': "It's {temperature}, it's a nice weather!",
+  'extra.only_english': "I'm only available in english."
 };
 
 module.exports = {

--- a/src/classes/config/ConfigValidator.ts
+++ b/src/classes/config/ConfigValidator.ts
@@ -87,7 +87,10 @@ class ConfigValidator {
         return customValidator(value);
       }
 
-      const type = this.types[key] || 'string';
+      const type = this.types[key];
+      if (!type) {
+        return;
+      }
 
       if (Array.isArray(type)) {
         const valid = type.some((t) => {

--- a/src/classes/data/RedisDataProvider.ts
+++ b/src/classes/data/RedisDataProvider.ts
@@ -172,6 +172,11 @@ class RedisDataProvider extends DataProvider {
    */
   public async _clear(startsWith: string): Promise<void> {
     const keys = await this.redis.keys(`${startsWith}*`);
+
+    if (!keys || keys.length < 1) {
+      return;
+    }
+
     await this.redis.del(keys);
   }
 

--- a/src/classes/locale/Localizer.ts
+++ b/src/classes/locale/Localizer.ts
@@ -164,6 +164,8 @@ class Localizer {
 
   /**
    * Get the formatter object to format the message of the given key and locale.
+   * If no message for the given locale exists, then the message for the default locale
+   * will be used.
    * @param key The key of the message to translate.
    * @param locale The locale to translate the message to.
    * @returns The formatter object for translating the message.
@@ -177,13 +179,13 @@ class Localizer {
       throw new Error(`No messages with locale ${locale} exist!`);
     }
 
-    const message = messagesForLocale[key];
+    const message = messagesForLocale[key] || this.localeStrings[this.defaultLocale][key];
 
     if (!message) {
       throw new Error(`No message with key ${key} for locale ${locale} exists!`);
     }
 
-    return new IntlMessageFormat(this.localeStrings[locale][key]);
+    return new IntlMessageFormat(message);
   }
 }
 

--- a/src/classes/locale/Localizer.ts
+++ b/src/classes/locale/Localizer.ts
@@ -96,17 +96,50 @@ class Localizer {
    * will read the locale set for each guild and will initialize their localizer with that value.
    * In case the client does not have a data provider, you should still call this method, but the
    * localizers will be initialized with the default locale.
+   * This also registers event handlers for client#guildCreate and client#guildDelete events
+   * to automatically create or delete localizers if the bot joins or leaves another guild.
+   * You should use the `GUILDS` intent.
    * @returns A promise that resolves once all guild localizers are ready.
    * @throws Rejects if a guild localizer was being initialized with an unsupported locale retrieved
    * from the data provider. This may happen if the locale saved in the data provider was updated manually.
    */
   public init(): Promise<string[]> {
-    return Promise.all(this.client.guilds.cache.map((guild) => {
-      const localizer = new GuildLocalizer(this, guild);
-      this.guildLocalizers.set(guild.id, localizer);
+    this.client.on('guildCreate', this.handleGuildCreate.bind(this));
+    this.client.on('guildDelete', this.handleGuildDelete.bind(this));
 
-      return localizer.init();
-    }));
+    return Promise.all(this.client.guilds.cache.map((guild) => this.handleGuildCreate(guild)));
+  }
+
+  /**
+   * Handles the creation and initialization of a newly joined guild's localizer.
+   * @param guild The [guild](https://discord.js.org/#/docs/discord.js/stable/class/Guild) that was joined.
+   * @private
+   * @returns A promise that resolves once the guild localizer is ready.
+   * @throws Rejects if the guild localizer was being initialized with an unsupported locale retrieved
+   * from the data provider. This may happen if the locale saved in the data provider was updated manually.
+   */
+  private handleGuildCreate(guild: Discord.Guild): Promise<string> {
+    const localizer = new GuildLocalizer(this, guild);
+    this.guildLocalizers.set(guild.id, localizer);
+
+    return localizer.init();
+  }
+
+  /**
+   * Handles the deletion of the localizer of the guild that has been left.
+   * @param guild The [guild](https://discord.js.org/#/docs/discord.js/stable/class/Guild) that was left.
+   * @private
+   * @returns A promise that resolves once the guild localizer has been removed from both this and the data
+   * provider (if any).
+   */
+  private handleGuildDelete(guild: Discord.Guild): Promise<void> {
+    this.guildLocalizers.delete(guild.id);
+
+    if (!this.client.dataProvider) {
+      return Promise.resolve();
+    }
+
+    return this.client.dataProvider.delete(guild, this.options.dataProviderKey || 'locale');
   }
 
   /**

--- a/test/classes/config/ConfigValidator.spec.ts
+++ b/test/classes/config/ConfigValidator.spec.ts
@@ -65,19 +65,16 @@ describe('Classes: Config: ConfigValidator', () => {
       }).toThrow();
     });
 
-    it('should not throw if config contains extraneous keys that resolve to a string.', () => {
+    it('should not throw if config contains extraneous keys of any type.', () => {
       expect(() => {
         validator.validate({ EXTRA: '123' });
       }).not.toThrow();
-    });
-
-    it('should throw if config contains extraneous keys that resolve to something other than a string.', () => {
-      expect(() => {
-        validator.validate({ EXTRA: false });
-      }).toThrow();
       expect(() => {
         validator.validate({ EXTRA: 123 });
-      }).toThrow();
+      }).not.toThrow();
+      expect(() => {
+        validator.validate({ EXTRA: false });
+      }).not.toThrow();
     });
 
     it('should throw if non nullable config is null.', () => {

--- a/test/classes/locale/Localizer.spec.ts
+++ b/test/classes/locale/Localizer.spec.ts
@@ -101,6 +101,12 @@ describe('Classes: Locale: Localizer', () => {
       expect(translated2).toBe('Bye');
     });
 
+    it('should use the default locale if message key does not exist in target locale but does in the default one.', () => {
+      expect(localizer.translate('exists.only.in.en', 'en')).toBe('I only exist in english');
+      expect(localizer.translate('exists.only.in.en', 'es')).toBe('I only exist in english');
+      expect(localizer.translate('exists.only.in.en', 'fr')).toBe('I only exist in english');
+    });
+
     it('should return the message string translated with values applied.', () => {
       const name = 'moonstar';
       const english = localizer.translate('message.test.with_value', 'en', { name });

--- a/test/classes/locale/Localizer.spec.ts
+++ b/test/classes/locale/Localizer.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable dot-notation */
 import Discord from 'discord.js';
 import Localizer from '../../../src/classes/locale/Localizer';
 import GuildLocalizer from '../../../src/classes/locale/GuildLocalizer';
@@ -38,6 +39,23 @@ describe('Classes: Locale: Localizer', () => {
       return localizer.init()
         .then((locales) => {
           expect(locales).toStrictEqual(['en', 'en', 'en']);
+        });
+    });
+
+    it('should register guildCreate and guildDelete event handlers.', () => {
+      return localizer.init()
+        .then(() => {
+          expect(clientMock.on).toHaveBeenCalledWith('guildCreate', expect.anything());
+          expect(clientMock.on).toHaveBeenCalledWith('guildDelete', expect.anything());
+        });
+    });
+  });
+
+  describe('private handleGuildDelete()', () => {
+    it('should delete the localizer for the guild.', () => {
+      return localizer['handleGuildDelete'](guildMock)
+        .then(() => {
+          expect(localizer.guildLocalizers.has(guildMock.id)).toBe(false);
         });
     });
   });


### PR DESCRIPTION
### :pencil: Checklist

Make sure that your PR fulfills these requirements:

- [x] Tests have been added for this feature.
- [x] Code is properly documented.
- [x] All tests pass on your local machine.
- [x] Code has been linted with the proper rules.
- [x] I have added the correct assignees for code review.

### :page_facing_up: Description

This PR adds the following fixes:

- Changed how config keys that had no types specified behave. They used to default to string and now the validation is skipped.
- `localizer.t()` now returns a message in the default locale in case it is not found for the specific locale instead of throwing and error.
- Fixed a bug where guild localizers would not be created or removed when the bot entered a guild or left one.
- Fixed a bug where `RedisDataProvider.clear()` would throw if a guild had no keys associated.

### :pushpin: Does this PR address any issue?

> If so, add the # of the issue this is addressing.
