### PR TITLE
Handling Interaction errors

### DIFF
--- a/__mocks__/discordMocks.ts
+++ b/__mocks__/discordMocks.ts
@@ -164,7 +164,10 @@ export class InteractionMock {
   public isCommand: jest.Mock;
   public inGuild: jest.Mock;
   public reply: jest.Mock;
+  public editReply: jest.Mock;
   public options: unknown;
+  public replied: boolean;
+  public deferred: boolean;
 
   constructor() {
     this.guild = new GuildMock();
@@ -173,8 +176,11 @@ export class InteractionMock {
     this.isCommand = jest.fn();
     this.inGuild = jest.fn();
     this.reply = jest.fn();
+    this.editReply = jest.fn();
     this.options = {
       getString: jest.fn()
     };
+    this.replied = false;
+    this.deferred = false;
   }
 }

--- a/example/commands/slash/ThrowSlashCommand.js
+++ b/example/commands/slash/ThrowSlashCommand.js
@@ -12,7 +12,8 @@ class ThrowSlashCommand extends SlashCommand {
     });
   }
 
-  run(interaction) {
+  async run(interaction) {
+    await interaction.reply('hi');
     throw new Error('Oops!');
   }
 }

--- a/src/classes/command/SlashCommand.ts
+++ b/src/classes/command/SlashCommand.ts
@@ -143,9 +143,15 @@ abstract class SlashCommand extends Command<Discord.CommandInteraction> {
       }
     }
 
-    await interaction.reply({
-      content: `An error has occurred when running the command ${this.name}.${contactOwner}`
-    });
+    if (interaction.deferred || interaction.replied) {
+      await interaction.editReply({
+        content: `An error has occurred when running the command ${this.name}.${contactOwner}`
+      });
+    } else {
+      await interaction.reply({
+        content: `An error has occurred when running the command ${this.name}.${contactOwner}`
+      });
+    }
   }
 }
 


### PR DESCRIPTION
### :pencil: Checklist

Make sure that your PR fulfills these requirements:

- [x] Tests have been added for this feature.
- [x] Code is properly documented.
- [x] All tests pass on your local machine.
- [x] Code has been linted with the proper rules.
- [ ] I have added the correct assignees for code review.

### :page_facing_up: Description

This PR fixes a bug where the bot would crash if trying to handle a command error where the interaction had already been replied or deferred.

### :pushpin: Does this PR address any issue?

#58 
